### PR TITLE
chore(mcp): 1.1.1 — drop generate-shim for warnings/reachability

### DIFF
--- a/src/Umbraco.Community.SchemeWeaver.Mcp/CHANGELOG.md
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the SchemeWeaver MCP server are documented here.
+
+## 1.1.1
+
+- Remove the generate-shim in the `save-schema-mapping` tool. The `reachability`
+  and `warnings` output-only fields are now folded into the OpenAPI
+  `SchemaMappingDto` and flow straight from the generated Orval client, so
+  `outputSchema` is the generated `postSchemeweaverMappingsResponse` with no
+  hand-written `.extend()`. No behavioural change for callers.
+
+## 1.1.0
+
+- Surface `reachability` and structural `warnings` on the save/read mapping
+  responses.

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/dist/index.js
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/dist/index.js
@@ -31381,7 +31381,7 @@ var EMPTY_COMPLETION_RESULT = {
 
 // package.json
 var package_default = {
-  version: "1.1.0"};
+  version: "1.1.1"};
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var ReadBuffer = class {
@@ -33239,7 +33239,14 @@ var getSchemeweaverMappingsResponseItem = object2({
     "resolverConfig": string2().nullish(),
     "dynamicRootConfig": string2().nullish(),
     "targetPieceKey": string2().nullish()
-  }))
+  })),
+  "reachability": string2().nullish(),
+  "warnings": array(object2({
+    "severity": string2(),
+    "schemaType": string2(),
+    "path": string2(),
+    "message": string2()
+  })).nullish()
 });
 object2({
   "contentTypeAlias": string2(),
@@ -33260,7 +33267,14 @@ object2({
     "resolverConfig": string2().nullish(),
     "dynamicRootConfig": string2().nullish(),
     "targetPieceKey": string2().nullish()
-  }))
+  })),
+  "reachability": string2().nullish(),
+  "warnings": array(object2({
+    "severity": string2(),
+    "schemaType": string2(),
+    "path": string2(),
+    "message": string2()
+  })).nullish()
 });
 var postSchemeweaverMappingsResponse = object2({
   "contentTypeAlias": string2(),
@@ -33281,7 +33295,14 @@ var postSchemeweaverMappingsResponse = object2({
     "resolverConfig": string2().nullish(),
     "dynamicRootConfig": string2().nullish(),
     "targetPieceKey": string2().nullish()
-  }))
+  })),
+  "reachability": string2().nullish(),
+  "warnings": array(object2({
+    "severity": string2(),
+    "schemaType": string2(),
+    "path": string2(),
+    "message": string2()
+  })).nullish()
 });
 var getSchemeweaverMappingsByContentTypeAliasParams = object2({
   "contentTypeAlias": string2()
@@ -33305,7 +33326,14 @@ var getSchemeweaverMappingsByContentTypeAliasResponse = object2({
     "resolverConfig": string2().nullish(),
     "dynamicRootConfig": string2().nullish(),
     "targetPieceKey": string2().nullish()
-  }))
+  })),
+  "reachability": string2().nullish(),
+  "warnings": array(object2({
+    "severity": string2(),
+    "schemaType": string2(),
+    "path": string2(),
+    "message": string2()
+  })).nullish()
 });
 object2({
   "contentTypeAlias": string2()
@@ -33761,17 +33789,7 @@ var inputSchema8 = {
     "The complete set of property mappings. Saving REPLACES the existing mapping wholesale \u2014 include every mapping you want to keep, not just the changed ones."
   )
 };
-var outputSchema10 = postSchemeweaverMappingsResponse.extend({
-  reachability: external_exports.string().optional(),
-  warnings: external_exports.array(
-    external_exports.object({
-      severity: external_exports.string(),
-      schemaType: external_exports.string().nullish(),
-      path: external_exports.string().nullish(),
-      message: external_exports.string()
-    })
-  ).optional()
-});
+var outputSchema10 = postSchemeweaverMappingsResponse;
 var saveSchemaMappingTool = {
   name: "save-schema-mapping",
   description: "Creates or replaces the SchemeWeaver mapping for an Umbraco content type, defining how its content is expressed as Schema.org JSON-LD. Recommended workflow: (1) get-content-type-properties and get-schema-type-properties (ranked=true) to understand both sides, (2) suggest-property-mappings for the heuristic baseline, (3) reason about each schema property semantically \u2014 correct bad suggestions, add mappings the heuristic missed, use nested types for complex values \u2014 then save with this tool, and (4) verify with preview-json-ld and fix any validation issues it reports. IMPORTANT: inspect the `warnings` array on the response \u2014 it flags properties mapped outside their Schema.org range that will be SILENTLY DROPPED from the JSON-LD (e.g. a non-CreativeWork type under hasPart); re-home those to a property like about/mainEntity. Also check `reachability`: composed-from-block means this type only emits inside a containing page's block mapping, never on its own URL. Note: this REPLACES any existing mapping for the content type; fetch it first with get-schema-mapping if you are amending.",

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/package.json
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco-community/schemeweaver-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "MCP server for Umbraco.Community.SchemeWeaver — lets AI assistants browse Schema.org types, inspect Umbraco content types, and create/verify schema mappings",
   "main": "dist/index.js",

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/api/generated/schemeWeaverApi.ts
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/api/generated/schemeWeaverApi.ts
@@ -114,6 +114,10 @@ export interface RankedSchemaPropertyInfo {
 
 export type SchemaMappingDtoIdOverride = null | string;
 
+export type SchemaMappingDtoReachability = null | string;
+
+export type SchemaMappingDtoWarnings = null | ValidationIssueDto[];
+
 export interface SchemaMappingDto {
   contentTypeAlias: string;
   contentTypeKey: string;
@@ -122,6 +126,8 @@ export interface SchemaMappingDto {
   isInherited: boolean;
   idOverride?: SchemaMappingDtoIdOverride;
   propertyMappings: PropertyMappingDto[];
+  reachability?: SchemaMappingDtoReachability;
+  warnings?: SchemaMappingDtoWarnings;
 }
 
 export type SchemaTypeInfoDescription = null | string;

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/api/generated/schemeWeaverApi.zod.ts
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/api/generated/schemeWeaverApi.zod.ts
@@ -53,7 +53,14 @@ export const getSchemeweaverMappingsResponseItem = zod.object({
   "resolverConfig": zod.string().nullish(),
   "dynamicRootConfig": zod.string().nullish(),
   "targetPieceKey": zod.string().nullish()
-}))
+})),
+  "reachability": zod.string().nullish(),
+  "warnings": zod.array(zod.object({
+  "severity": zod.string(),
+  "schemaType": zod.string(),
+  "path": zod.string(),
+  "message": zod.string()
+})).nullish()
 })
 export const getSchemeweaverMappingsResponse = zod.array(getSchemeweaverMappingsResponseItem)
 
@@ -77,7 +84,14 @@ export const postSchemeweaverMappingsBody = zod.object({
   "resolverConfig": zod.string().nullish(),
   "dynamicRootConfig": zod.string().nullish(),
   "targetPieceKey": zod.string().nullish()
-}))
+})),
+  "reachability": zod.string().nullish(),
+  "warnings": zod.array(zod.object({
+  "severity": zod.string(),
+  "schemaType": zod.string(),
+  "path": zod.string(),
+  "message": zod.string()
+})).nullish()
 })
 
 export const postSchemeweaverMappingsResponse = zod.object({
@@ -99,7 +113,14 @@ export const postSchemeweaverMappingsResponse = zod.object({
   "resolverConfig": zod.string().nullish(),
   "dynamicRootConfig": zod.string().nullish(),
   "targetPieceKey": zod.string().nullish()
-}))
+})),
+  "reachability": zod.string().nullish(),
+  "warnings": zod.array(zod.object({
+  "severity": zod.string(),
+  "schemaType": zod.string(),
+  "path": zod.string(),
+  "message": zod.string()
+})).nullish()
 })
 
 
@@ -126,7 +147,14 @@ export const getSchemeweaverMappingsByContentTypeAliasResponse = zod.object({
   "resolverConfig": zod.string().nullish(),
   "dynamicRootConfig": zod.string().nullish(),
   "targetPieceKey": zod.string().nullish()
-}))
+})),
+  "reachability": zod.string().nullish(),
+  "warnings": zod.array(zod.object({
+  "severity": zod.string(),
+  "schemaType": zod.string(),
+  "path": zod.string(),
+  "message": zod.string()
+})).nullish()
 })
 
 

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/api/schemeweaver-openapi.json
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/api/schemeweaver-openapi.json
@@ -913,6 +913,21 @@
             "items": {
               "$ref": "#/components/schemas/PropertyMappingDto"
             }
+          },
+          "reachability": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "warnings": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ValidationIssueDto"
+            }
           }
         }
       },

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/tools/schemeweaver/post/save-schema-mapping.ts
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/src/umbraco-api/tools/schemeweaver/post/save-schema-mapping.ts
@@ -137,27 +137,12 @@ const inputSchema = {
     ),
 };
 
-// Forward-compatible: the save response is re-fetched through the single-read
-// path, so it carries `reachability` (routed-page | composed-from-block |
-// unknown) and structural `warnings` — properties mapped outside their
-// Schema.org range that will be SILENTLY DROPPED from the emitted JSON-LD.
-// Surface them via .extend() so the generated zod object does not strip them
-// before the Orval client is regenerated. Both optional → inert when absent.
-// NOTE (leader): drop this shim once `npm run generate` folds the fields into
-// the generated postSchemeweaverMappingsResponse schema.
-const outputSchema = postSchemeweaverMappingsResponse.extend({
-  reachability: z.string().optional(),
-  warnings: z
-    .array(
-      z.object({
-        severity: z.string(),
-        schemaType: z.string().nullish(),
-        path: z.string().nullish(),
-        message: z.string(),
-      })
-    )
-    .optional(),
-});
+// The save response is re-fetched through the single-read path, so it carries
+// `reachability` (routed-page | composed-from-block | unknown) and structural
+// `warnings` — properties mapped outside their Schema.org range that will be
+// SILENTLY DROPPED from the emitted JSON-LD. Both now flow straight from the
+// generated client (folded into the OpenAPI SchemaMappingDto), so no shim.
+const outputSchema = postSchemeweaverMappingsResponse;
 
 const saveSchemaMappingTool: ToolDefinition<typeof inputSchema, typeof outputSchema> = {
   name: "save-schema-mapping",


### PR DESCRIPTION
## Summary

Removes the leftover Orval generate-shim in the `save-schema-mapping` MCP tool. Previously `outputSchema` hand-extended the generated `postSchemeweaverMappingsResponse` with `reachability` and `warnings` because the committed OpenAPI spec (`schemeweaver-openapi.json`, Orval's input) was stale and stripped those output-only fields.

**Root cause (case b):** the C# `SchemaMappingDto` already exposes `Reachability` (`string?`) and `Warnings` (`List<ValidationIssueDto>`) — both output-only, documented as set on read/save. The committed OpenAPI doc that Orval reads simply predated those properties.

## Changes
- Fold `reachability` + `warnings` into the OpenAPI `SchemaMappingDto` (`schemeweaver-openapi.json`).
- Regenerate the Orval client (`schemeWeaverApi.ts`) and Zod schemas (`schemeWeaverApi.zod.ts`) via `orval` — `postSchemeweaverMappingsResponse` now carries both fields natively.
- Drop the `.extend()` shim in `save-schema-mapping.ts`; `outputSchema = postSchemeweaverMappingsResponse`. No behavioural change for callers.
- Rebuild `dist/index.js` (the tracked published bundle).
- Bump version `1.1.0` → `1.1.1` and add `CHANGELOG.md`.

## Verification
- `npm run build` (tsup + type generation): **pass**.
- `npm test` (jest): the unit/non-host suite passes; the 8 failures are pre-existing `HOST-DEPENDENT` integration tests that require a live Umbraco at `localhost:44308` (connection refused) — identical failure count on a clean tree, unaffected by this change.

## Scope notes
- Only the **save** shim was removed (per task scope). The shared `SchemaMappingDto` regeneration means the equivalent `get-schema-mapping` / `get-all-schema-mappings` shims now extend fields that already exist in the generated client — they remain in place and are harmless/idempotent, to be tidied separately.
- **No `npm publish` was run** — this stops before any public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)