### PR TITLE
feat(engine): media pickers emit ImageObject (and Uri), in and out of blocks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
     <!-- uSync line for this major (stable) -->
     <SchemeWeaverUSyncVersion>17.3.0</SchemeWeaverUSyncVersion>
     <!-- Major-aligned stable package version for the Umbraco 17 line -->
-    <SchemeWeaverPackageVersion>17.10.2</SchemeWeaverPackageVersion>
+    <SchemeWeaverPackageVersion>17.10.3</SchemeWeaverPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UmbracoMajor)' == '18'">
@@ -55,7 +55,7 @@
     <!-- Major-aligned stable package version for the Umbraco 18 line. Its
          [18.0.0, 19.0.0) Umbraco.Cms range is mutually exclusive with the 17 leg's
          [17.4.0, 18.0.0), so NuGet only ever resolves one of the two per consumer. -->
-    <SchemeWeaverPackageVersion>18.5.2</SchemeWeaverPackageVersion>
+    <SchemeWeaverPackageVersion>18.5.3</SchemeWeaverPackageVersion>
     <DefineConstants>$(DefineConstants);UMBRACO18</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Umbraco.Community.SchemeWeaver/Graph/Pieces/PrimaryImagePiece.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Graph/Pieces/PrimaryImagePiece.cs
@@ -3,6 +3,7 @@ using Schema.NET;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Community.SchemeWeaver.Services.Media;
 using Umbraco.Extensions;
 
 namespace Umbraco.Community.SchemeWeaver.Graph.Pieces;
@@ -53,23 +54,7 @@ public sealed class PrimaryImagePiece : IGraphPiece
     public Thing? Build(GraphPieceContext ctx)
     {
         var media = GetMediaProperty(ctx.Content);
-        if (media is null)
-            return null;
-
-        var url = _urlProvider.GetMediaUrl(media, UrlMode.Absolute);
-        if (string.IsNullOrEmpty(url))
-            return null;
-
-        var image = new ImageObject();
-        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
-            image.Url = uri;
-
-        if (media.Value<int?>("umbracoWidth") is int width && width > 0)
-            image.Width = new QuantitativeValue { Value = width };
-        if (media.Value<int?>("umbracoHeight") is int height && height > 0)
-            image.Height = new QuantitativeValue { Value = height };
-
-        return image;
+        return media is null ? null : MediaImageObjectFactory.Create(media, _urlProvider);
     }
 
     private IPublishedContent? GetMediaProperty(IPublishedContent content)

--- a/src/Umbraco.Community.SchemeWeaver/Services/Media/MediaImageObjectFactory.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Media/MediaImageObjectFactory.cs
@@ -1,0 +1,65 @@
+using Schema.NET;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Extensions;
+
+namespace Umbraco.Community.SchemeWeaver.Services.Media;
+
+/// <summary>
+/// Builds a Schema.NET <see cref="ImageObject"/> from an Umbraco media node.
+/// Centralises the media → ImageObject mapping (absolute URL, intrinsic
+/// width/height, best-effort caption) shared by the primary-image graph piece
+/// and the media picker property resolver.
+/// </summary>
+public static class MediaImageObjectFactory
+{
+    private static readonly string[] _captionAliases =
+    [
+        "altText",
+        "alternativeText",
+        "caption",
+        "imageAltText"
+    ];
+
+    /// <summary>
+    /// Creates an <see cref="ImageObject"/> for the supplied media node, or
+    /// <c>null</c> when the media yields no resolvable absolute URL (e.g. the
+    /// media item has been deleted or its file is missing).
+    /// </summary>
+    public static ImageObject? Create(IPublishedContent media, IPublishedUrlProvider urlProvider)
+    {
+        var url = urlProvider.GetMediaUrl(media, UrlMode.Absolute);
+        if (string.IsNullOrEmpty(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return null;
+
+        var image = new ImageObject
+        {
+            Url = uri
+        };
+
+        if (media.Value<int?>("umbracoWidth") is int width && width > 0)
+            image.Width = new QuantitativeValue { Value = width };
+        if (media.Value<int?>("umbracoHeight") is int height && height > 0)
+            image.Height = new QuantitativeValue { Value = height };
+
+        var caption = ResolveCaption(media);
+        if (!string.IsNullOrWhiteSpace(caption))
+        {
+            image.Name = caption;
+            image.Caption = caption;
+        }
+
+        return image;
+    }
+
+    private static string? ResolveCaption(IPublishedContent media)
+    {
+        foreach (var alias in _captionAliases)
+        {
+            var value = media.Value<string?>(alias);
+            if (!string.IsNullOrWhiteSpace(value))
+                return value;
+        }
+        return null;
+    }
+}

--- a/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
@@ -457,14 +457,52 @@ public class BlockContentResolver : IPropertyValueResolver
 
     /// <summary>
     /// Resolves a property value from a block element.
-    /// Delegates to <see cref="SchemaPropertySetter.ResolveElementPropertyValue"/> which handles
-    /// media pickers, editor alias detection, and string extraction.
+    /// When a <see cref="PropertyResolverContext.ResolverFactory"/> is available the block element
+    /// property is routed through the per-editor resolver pipeline (so e.g. a block media property
+    /// flows through <c>MediaPickerResolver</c> and returns a Schema.NET <c>ImageObject</c> rather
+    /// than hitting the raw-JSON fallback). The child context keeps <see cref="PropertyResolverContext.Content"/>
+    /// as the PAGE node and carries the block element property under
+    /// <see cref="PropertyResolverContext.Property"/>. Falls back to the static
+    /// <see cref="SchemaPropertySetter.ResolveElementPropertyValue"/> helper when no factory is
+    /// supplied (keeps unit tests that don't wire a factory green) or when the factory yields no
+    /// resolver for the editor alias.
     /// </summary>
     private static object? ResolveBlockElementProperty(
         IPublishedElement blockContent,
         string propertyAlias,
         PropertyResolverContext context)
     {
+        if (context.ResolverFactory is { } factory)
+        {
+            var prop = blockContent.GetProperty(propertyAlias);
+            if (prop is null)
+                return null;
+
+            // Route through the per-editor resolver factory so the block element property flows
+            // through the same pipeline as top-level properties (media pickers, dates, etc.).
+            IPropertyValueResolver? resolver = factory.GetResolver(prop.PropertyType?.EditorAlias);
+            if (resolver is not null)
+            {
+                var childContext = new PropertyResolverContext
+                {
+                    Content = context.Content,                 // stays the PAGE node
+                    Mapping = context.Mapping,
+                    PropertyAlias = propertyAlias,
+                    SchemaTypeRegistry = context.SchemaTypeRegistry,
+                    MappingRepository = context.MappingRepository,
+                    HttpContextAccessor = context.HttpContextAccessor,
+                    ResolverFactory = factory,
+                    Property = prop,                           // the block element property
+                    RecursionDepth = context.RecursionDepth,
+                    MaxRecursionDepth = context.MaxRecursionDepth,
+                    VisitedContentKeys = context.VisitedContentKeys,
+                    Culture = context.Culture
+                };
+
+                return resolver.Resolve(childContext);
+            }
+        }
+
         return SchemaPropertySetter.ResolveElementPropertyValue(
             blockContent, propertyAlias, context.HttpContextAccessor);
     }

--- a/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/MediaPickerResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/MediaPickerResolver.cs
@@ -1,23 +1,31 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Schema.NET;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Community.SchemeWeaver.Services.Media;
 
 namespace Umbraco.Community.SchemeWeaver.Services.Resolvers;
 
 /// <summary>
-/// Resolves media picker property values to absolute media URLs for Schema.NET.
+/// Resolves media picker property values to Schema.NET <see cref="ImageObject"/>(s).
 /// Handles both single and multi-value media pickers (MediaPicker3 and legacy MediaPicker).
-/// Extracts the URL from the media's umbracoFile property to avoid requiring IPublishedUrlProvider.
+/// Returns a single <see cref="ImageObject"/> for one media item, a
+/// <see cref="List{ImageObject}"/> for several, or <c>null</c> when no media resolves.
+/// Each ImageObject carries an absolute URL plus intrinsic width/height via
+/// <see cref="MediaImageObjectFactory"/>.
 /// </summary>
 public class MediaPickerResolver : IPropertyValueResolver
 {
     private readonly ILogger<MediaPickerResolver> _logger;
+    private readonly IPublishedUrlProvider _urlProvider;
 
-    public MediaPickerResolver(ILogger<MediaPickerResolver> logger)
+    public MediaPickerResolver(
+        ILogger<MediaPickerResolver> logger,
+        IPublishedUrlProvider urlProvider)
     {
         _logger = logger;
+        _urlProvider = urlProvider;
     }
 
     public IEnumerable<string> SupportedEditorAliases =>
@@ -31,67 +39,36 @@ public class MediaPickerResolver : IPropertyValueResolver
         if (value is null)
             return null;
 
-        // MediaPicker3 returns MediaWithCrops or IEnumerable<MediaWithCrops>
-        IPublishedContent? mediaContent = value switch
+        // MediaPicker3 returns MediaWithCrops or IEnumerable<MediaWithCrops>;
+        // legacy MediaPicker returns IPublishedContent or IEnumerable<IPublishedContent>.
+        IEnumerable<IPublishedContent?> mediaNodes = value switch
         {
-            MediaWithCrops single => single.Content,
-            IEnumerable<MediaWithCrops> multiple => multiple.FirstOrDefault()?.Content,
-            IPublishedContent content => content,
-            IEnumerable<IPublishedContent> contents => contents.FirstOrDefault(),
-            _ => null
+            MediaWithCrops single => [single.Content],
+            IEnumerable<MediaWithCrops> multiple => multiple.Select(m => m.Content),
+            IPublishedContent content => [content],
+            IEnumerable<IPublishedContent> contents => contents,
+            _ => []
         };
 
-        if (mediaContent is null)
+        var images = new List<ImageObject>();
+        foreach (var node in mediaNodes)
+        {
+            if (node is null)
+                continue;
+
+            var image = MediaImageObjectFactory.Create(node, _urlProvider);
+            if (image is not null)
+                images.Add(image);
+        }
+
+        if (images.Count == 0)
         {
             _logger.LogWarning(
-                "Media picker property '{PropertyAlias}' on content '{ContentName}' resolved to null media item — the media may have been deleted",
+                "Media picker property '{PropertyAlias}' on content '{ContentName}' resolved to no usable media — items may have been deleted or their files are missing",
                 context.PropertyAlias, context.Content.Name);
             return null;
         }
 
-        var relativeUrl = GetMediaUrl(mediaContent);
-        if (string.IsNullOrEmpty(relativeUrl))
-            return null;
-
-        return ToAbsoluteUrl(relativeUrl, context.HttpContextAccessor);
-    }
-
-    /// <summary>
-    /// Extracts the media URL from the umbracoFile property.
-    /// The value can be a plain string path, or an ImageCropperValue with a Src property.
-    /// </summary>
-    private string? GetMediaUrl(IPublishedContent mediaContent)
-    {
-        var umbracoFile = mediaContent.GetProperty("umbracoFile");
-        if (umbracoFile is null)
-        {
-            _logger.LogWarning(
-                "Media item '{MediaName}' has no umbracoFile property — the media file may be missing",
-                mediaContent.Name);
-            return null;
-        }
-
-        var fileValue = umbracoFile.GetValue();
-        if (fileValue is null)
-            return null;
-
-        // ImageCropperValue has a Src property with the URL
-        if (fileValue is ImageCropperValue cropperValue)
-            return cropperValue.Src;
-
-        // Plain string path
-        return fileValue.ToString();
-    }
-
-    private static string ToAbsoluteUrl(string url, IHttpContextAccessor httpContextAccessor)
-    {
-        if (!url.StartsWith('/'))
-            return url;
-
-        var request = httpContextAccessor.HttpContext?.Request;
-        if (request is null)
-            return url;
-
-        return $"{request.Scheme}://{request.Host}{url}";
+        return images.Count == 1 ? images[0] : images;
     }
 }

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
@@ -42,6 +42,23 @@ public static class SchemaPropertySetter
             return;
         }
 
+        // Media values now arrive as Schema.NET ImageObject(s). When the target accepts
+        // IImageObject (e.g. Article.Image, Organization.Logo) we fall through to the normal
+        // OneOrMany/Values/collection handling below, which sets the ImageObject(s) directly.
+        // But some targets accept only a Uri leaf (e.g. Thing.Url, contentUrl, sameAs) and NOT
+        // IImageObject — an ImageObject would otherwise be dropped. Downgrade it to its URL.
+        if (IsImageObjectValue(value)
+            && !TargetAcceptsLeaf(targetType, typeof(IImageObject))
+            && TargetAcceptsLeaf(targetType, typeof(Uri)))
+        {
+            var downgraded = DowngradeImageToUri(value);
+            if (downgraded is not null)
+            {
+                SetPropertyValue(instance, propertyName, downgraded, logger);
+                return;
+            }
+        }
+
         // Try to find an implicit conversion operator that accepts our value type
         var converted = TryConvertViaImplicit(targetType, value);
         if (converted is not null)
@@ -135,6 +152,90 @@ public static class SchemaPropertySetter
 
         Walk(targetType);
         return results;
+    }
+
+    /// <summary>
+    /// Whether a resolved value is a Schema.NET image — a single <see cref="IImageObject"/>,
+    /// or a non-empty enumerable whose every element is an <see cref="IImageObject"/>. Used to
+    /// decide whether the value needs image-aware handling (range-aware set or Uri downgrade).
+    /// </summary>
+    private static bool IsImageObjectValue(object? v)
+    {
+        if (v is IImageObject)
+            return true;
+
+        if (v is IEnumerable<IImageObject>)
+            return true;
+
+        // Non-generic enumerables (e.g. a List<object> of ImageObjects): every element must be
+        // an IImageObject and there must be at least one. Exclude string (it's IEnumerable<char>).
+        if (v is IEnumerable and not string)
+        {
+            var items = ((IEnumerable)v).Cast<object?>().ToList();
+            return items.Count > 0 && items.All(x => x is IImageObject);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Walks a (possibly generic) target property type collecting its non-generic leaf type
+    /// arguments — mirroring <see cref="CollectCandidateThingInterfaces"/>'s generic-walking style —
+    /// and reports whether any leaf is equal to, or assignable from, <paramref name="leafType"/>.
+    /// <see cref="Nullable{T}"/> leaves are unwrapped. E.g. <c>OneOrMany&lt;Values&lt;IImageObject, Uri&gt;&gt;</c>
+    /// accepts both <c>IImageObject</c> and <c>Uri</c>; <c>OneOrMany&lt;Uri&gt;</c> accepts only <c>Uri</c>.
+    /// </summary>
+    private static bool TargetAcceptsLeaf(Type targetType, Type leafType)
+    {
+        var seen = new HashSet<Type>();
+        var found = false;
+
+        void Walk(Type t)
+        {
+            if (found || !seen.Add(t))
+                return;
+
+            if (t.IsGenericType)
+            {
+                foreach (var arg in t.GetGenericArguments())
+                    Walk(arg);
+                return;
+            }
+
+            var leaf = Nullable.GetUnderlyingType(t) ?? t;
+            if (leaf == leafType || leaf.IsAssignableFrom(leafType))
+                found = true;
+        }
+
+        Walk(targetType);
+        return found;
+    }
+
+    /// <summary>
+    /// Reduces an image value to a plain <see cref="Uri"/> (single) or <c>List&lt;Uri&gt;</c> (multi)
+    /// for targets that accept only a Uri leaf. Reads each image's <c>Url</c> — a Schema.NET
+    /// <c>OneOrMany&lt;Uri&gt;</c> — and takes its first entry, skipping images without a URL.
+    /// Returns null when nothing usable remains.
+    /// </summary>
+    private static object? DowngradeImageToUri(object value)
+    {
+        if (value is IImageObject singleImage)
+            return singleImage.Url.FirstOrDefault();
+
+        IEnumerable<IImageObject> images = value switch
+        {
+            IEnumerable<IImageObject> typed => typed,
+            IEnumerable and not string => ((IEnumerable)value).Cast<object?>().OfType<IImageObject>(),
+            _ => []
+        };
+
+        var uris = images
+            .Select(img => img.Url.FirstOrDefault())
+            .Where(uri => uri is not null)
+            .Cast<Uri>()
+            .ToList();
+
+        return uris.Count > 0 ? uris : null;
     }
 
     /// <summary>
@@ -654,9 +755,10 @@ public static class SchemaPropertySetter
         var editorAlias = prop.PropertyType?.EditorAlias;
         if (editorAlias is "Umbraco.MediaPicker3" or "Umbraco.MediaPicker")
         {
-            var mediaUrl = TryExtractMediaUrl(value, httpContextAccessor);
-            if (mediaUrl is not null)
-                return mediaUrl;
+            // Media pickers must NEVER fall through to value.ToString() below — that would
+            // leak raw MediaWithCrops JSON. Return the extracted URL (which may be null when
+            // the picker is empty or the media has no file) directly.
+            return TryExtractMediaUrl(value, httpContextAccessor);
         }
 
         var stringValue = value.ToString();

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/BlockContentResolverTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/BlockContentResolverTests.cs
@@ -1808,6 +1808,161 @@ public class BlockContentResolverTests
         list.Should().BeEquivalentTo(new[] { "200g flour", "2 eggs" });
     }
 
+    // --- Block element property routing through the resolver factory (media ImageObject seam) ---
+
+    // A block media property must flow through the per-editor resolver pipeline (via the factory)
+    // rather than the static raw-JSON helper. Here a stub resolver stands in for MediaPickerResolver
+    // and returns a Schema.NET ImageObject; the routing must wire the BLOCK ELEMENT property into the
+    // factory-resolved value and set it on the mapped block Thing.
+    [Fact]
+    public void ResolveBlockElementProperty_WithFactory_UsesFactoryResolver()
+    {
+        var block = CreateBlockElementWithEditors(
+            "reviewItem",
+            ("photo", "[{\"mediaKey\":\"abc\",\"umbracoFile\":\"/media/x.jpg\"}]", "Umbraco.MediaPicker3"));
+        var blockListModel = CreateBlockListModel(block);
+
+        var imageObject = new Schema.NET.ImageObject { Url = new Uri("https://cdn.example.com/photo.jpg") };
+
+        // Stub resolver standing in for MediaPickerResolver — captures the child context so we can
+        // assert the block element property (not the page property) was routed to it.
+        PropertyResolverContext? captured = null;
+        var mediaResolver = Substitute.For<IPropertyValueResolver>();
+        mediaResolver
+            .Resolve(Arg.Do<PropertyResolverContext>(c => captured = c))
+            .Returns(imageObject);
+
+        var factory = Substitute.For<IPropertyValueResolverFactory>();
+        factory.GetResolver(Arg.Any<string?>()).Returns(mediaResolver);
+
+        var resolverConfig = JsonSerializer.Serialize(new ResolverConfigModel
+        {
+            Routes = new List<BlockRoute>
+            {
+                new()
+                {
+                    BlockAlias = "reviewItem",
+                    NestedSchemaType = "Article",
+                    PropertyMappings = new List<NestedPropertyMapping>
+                    {
+                        new() { SchemaProperty = "image", ContentProperty = "photo" }
+                    }
+                }
+            }
+        });
+
+        var property = Substitute.For<IPublishedProperty>();
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(blockListModel);
+
+        var context = CreateContext(property, resolverConfig: resolverConfig, resolverFactory: factory);
+
+        var result = _sut.Resolve(context);
+
+        // Routing reached the factory with the block editor alias.
+        factory.Received().GetResolver("Umbraco.MediaPicker3");
+
+        // The child context carried the BLOCK ELEMENT property and kept the PAGE as Content.
+        captured.Should().NotBeNull();
+        captured!.Property!.Alias.Should().Be("photo");
+        captured.Content.Should().BeSameAs(context.Content);
+        captured.ResolverFactory.Should().BeSameAs(factory);
+
+        // The factory-resolved ImageObject flowed onto the mapped Thing (i.e. SetPropertyValue ran).
+        var article = ((IEnumerable<Schema.NET.Thing>)result!).Cast<Schema.NET.Article>().Single();
+        var jsonLd = article.ToString();
+        jsonLd.Should().Contain("ImageObject");
+        jsonLd.Should().Contain("photo.jpg");
+    }
+
+    // With no factory the resolver keeps its original behaviour: the static helper resolves a scalar
+    // text block property (existing tests exercise this implicitly; this pins it explicitly).
+    [Fact]
+    public void ResolveBlockElementProperty_NoFactory_FallsBackToStaticHelper()
+    {
+        var block = CreateBlockElement("faqItem", new Dictionary<string, object?>
+        {
+            ["questionText"] = "Static path still runs?"
+        });
+        var blockListModel = CreateBlockListModel(block);
+
+        var resolverConfig = JsonSerializer.Serialize(new ResolverConfigModel
+        {
+            NestedMappings = new List<NestedPropertyMapping>
+            {
+                new() { BlockAlias = "faqItem", SchemaProperty = "name", ContentProperty = "questionText" }
+            }
+        });
+
+        var property = Substitute.For<IPublishedProperty>();
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(blockListModel);
+
+        // No resolverFactory supplied — ResolverFactory is null on the context.
+        var context = CreateContext(property, nestedSchemaTypeName: "Question", resolverConfig: resolverConfig);
+        context.ResolverFactory.Should().BeNull();
+
+        var result = _sut.Resolve(context);
+
+        var question = ((IEnumerable<Schema.NET.Thing>)result!).Cast<Schema.NET.Question>().Single();
+        question.Name.First().Should().Be("Static path still runs?");
+    }
+
+    // Damaged media: the factory resolver returns null for the media property. The property must be
+    // omitted (not fall back to raw MediaWithCrops JSON), while a sibling scalar keeps the Thing.
+    [Fact]
+    public void ResolveBlockElementProperty_FactoryResolvesNull_PropertyOmitted_NoRawJson()
+    {
+        var block = CreateBlockElementWithEditors(
+            "reviewItem",
+            ("reviewTitle", "A great stay", "Umbraco.TextBox"),
+            ("photo", "[{\"mediaKey\":\"abc\",\"umbracoFile\":\"/media/x.jpg\",\"MediaWithCrops\":true}]", "Umbraco.MediaPicker3"));
+        var blockListModel = CreateBlockListModel(block);
+
+        // Media resolver returns null (damaged media); text resolver returns the scalar value.
+        var mediaResolver = Substitute.For<IPropertyValueResolver>();
+        mediaResolver.Resolve(Arg.Any<PropertyResolverContext>()).Returns((object?)null);
+
+        var textResolver = Substitute.For<IPropertyValueResolver>();
+        textResolver.Resolve(Arg.Any<PropertyResolverContext>()).Returns("A great stay");
+
+        var factory = Substitute.For<IPropertyValueResolverFactory>();
+        factory.GetResolver("Umbraco.MediaPicker3").Returns(mediaResolver);
+        factory.GetResolver("Umbraco.TextBox").Returns(textResolver);
+
+        var resolverConfig = JsonSerializer.Serialize(new ResolverConfigModel
+        {
+            Routes = new List<BlockRoute>
+            {
+                new()
+                {
+                    BlockAlias = "reviewItem",
+                    NestedSchemaType = "Article",
+                    PropertyMappings = new List<NestedPropertyMapping>
+                    {
+                        new() { SchemaProperty = "name", ContentProperty = "reviewTitle" },
+                        new() { SchemaProperty = "image", ContentProperty = "photo" }
+                    }
+                }
+            }
+        });
+
+        var property = Substitute.For<IPublishedProperty>();
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(blockListModel);
+
+        var context = CreateContext(property, resolverConfig: resolverConfig, resolverFactory: factory);
+
+        var result = _sut.Resolve(context);
+
+        var article = ((IEnumerable<Schema.NET.Thing>)result!).Cast<Schema.NET.Article>().Single();
+        var jsonLd = article.ToString();
+
+        // The Thing survived on the scalar, but the damaged media property is omitted — and crucially
+        // no raw MediaWithCrops / umbracoFile JSON leaked into the output.
+        jsonLd.Should().Contain("A great stay");
+        jsonLd.Should().NotContain("\"image\"");
+        jsonLd.Should().NotContain("umbracoFile");
+        jsonLd.Should().NotContain("MediaWithCrops");
+    }
+
     private static IPublishedElement CreateBlockElementWithNestedBlock(
         string contentTypeAlias,
         string nestedPropertyAlias,
@@ -1885,7 +2040,8 @@ public class BlockContentResolverTests
         IPublishedProperty? property,
         string? nestedSchemaTypeName = null,
         string? resolverConfig = null,
-        int recursionDepth = 0)
+        int recursionDepth = 0,
+        IPropertyValueResolverFactory? resolverFactory = null)
     {
         return new PropertyResolverContext
         {
@@ -1900,9 +2056,42 @@ public class BlockContentResolverTests
             SchemaTypeRegistry = _registry,
             MappingRepository = _repository,
             HttpContextAccessor = _httpContextAccessor,
+            ResolverFactory = resolverFactory,
             Property = property,
             RecursionDepth = recursionDepth,
             MaxRecursionDepth = 3
         };
+    }
+
+    /// <summary>
+    /// Builds a block element whose properties each carry an editor alias, so
+    /// <see cref="BlockContentResolver"/> can pick a per-editor resolver from the factory.
+    /// </summary>
+    private static IPublishedElement CreateBlockElementWithEditors(
+        string contentTypeAlias,
+        params (string Alias, object? Value, string? EditorAlias)[] properties)
+    {
+        var element = Substitute.For<IPublishedElement>();
+        var contentType = Substitute.For<IPublishedContentType>();
+        contentType.Alias.Returns(contentTypeAlias);
+        element.ContentType.Returns(contentType);
+        element.Key.Returns(Guid.NewGuid());
+
+        foreach (var (alias, value, editorAlias) in properties)
+        {
+            var prop = Substitute.For<IPublishedProperty>();
+            prop.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(value);
+            prop.Alias.Returns(alias);
+
+            var propType = Substitute.For<IPublishedPropertyType>();
+            propType.EditorAlias.Returns(editorAlias);
+            prop.PropertyType.Returns(propType);
+
+            // Umbraco property aliases are case-insensitive — mirror that here.
+            element.GetProperty(Arg.Is<string>(a => string.Equals(a, alias, StringComparison.OrdinalIgnoreCase)))
+                .Returns(prop);
+        }
+
+        return element;
     }
 }

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/MediaPickerResolverTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/MediaPickerResolverTests.cs
@@ -1,11 +1,16 @@
+using System.Linq;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Schema.NET;
 using Xunit;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Routing;
 using Umbraco.Community.SchemeWeaver.Models.Entities;
 using Umbraco.Community.SchemeWeaver.Persistence;
 using Umbraco.Community.SchemeWeaver.Services;
@@ -15,38 +20,64 @@ namespace Umbraco.Community.SchemeWeaver.Tests.Unit.Resolvers;
 
 public class MediaPickerResolverTests
 {
-    private readonly MediaPickerResolver _sut = new(NullLogger<MediaPickerResolver>.Instance);
-    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IPublishedUrlProvider _urlProvider = Substitute.For<IPublishedUrlProvider>();
+    private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+    private readonly MediaPickerResolver _sut;
+
+    static MediaPickerResolverTests()
+    {
+        // media.Value<int?>("umbracoWidth") flows through FriendlyPublishedContentExtensions,
+        // which resolves IPublishedValueFallback from StaticServiceProvider. Ensure it is set
+        // so the friendly extension does not throw during unit tests. Only set it when the
+        // ambient provider cannot already satisfy the dependency (e.g. under integration hosts).
+        if (StaticServiceProvider.Instance?.GetService<IPublishedValueFallback>() is null)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IPublishedValueFallback, NoopPublishedValueFallback>();
+            StaticServiceProvider.Instance = services.BuildServiceProvider();
+        }
+    }
 
     public MediaPickerResolverTests()
     {
-        _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Scheme = "https";
-        httpContext.Request.Host = new HostString("example.com");
-        _httpContextAccessor.HttpContext.Returns(httpContext);
+        _sut = new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance, _urlProvider);
     }
 
-    private static IPublishedContent CreateMediaContent(string url)
+    /// <summary>
+    /// Creates a media substitute whose absolute URL is served by <see cref="_urlProvider"/>,
+    /// optionally stubbing the intrinsic <c>umbracoWidth</c>/<c>umbracoHeight</c> properties.
+    /// </summary>
+    private IPublishedContent CreateMediaContent(string url, int? width = null, int? height = null)
     {
-        var umbracoFileProperty = Substitute.For<IPublishedProperty>();
-        umbracoFileProperty.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(url);
-
         var media = Substitute.For<IPublishedContent>();
-        media.GetProperty("umbracoFile").Returns(umbracoFileProperty);
+        _urlProvider
+            .GetMediaUrl(media, UrlMode.Absolute, Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<Uri?>())
+            .Returns(url);
+
+        if (width is int w)
+            StubIntProperty(media, "umbracoWidth", w);
+        if (height is int h)
+            StubIntProperty(media, "umbracoHeight", h);
+
         return media;
     }
 
-    private static IPublishedContent CreateMediaContentWithCropper(string url)
-    {
-        var cropperValue = new ImageCropperValue { Src = url };
-        var umbracoFileProperty = Substitute.For<IPublishedProperty>();
-        umbracoFileProperty.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(cropperValue);
+    /// <summary>
+    /// A media item whose URL cannot be resolved (deleted media / missing file) —
+    /// the url provider returns null for it, so the factory yields no ImageObject.
+    /// </summary>
+    private static IPublishedContent CreateDamagedMedia() => Substitute.For<IPublishedContent>();
 
-        var media = Substitute.For<IPublishedContent>();
-        media.GetProperty("umbracoFile").Returns(umbracoFileProperty);
-        return media;
+    private static void StubIntProperty(IPublishedContent media, string alias, int value)
+    {
+        var property = Substitute.For<IPublishedProperty>();
+        property.HasValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(true);
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(value);
+        media.GetProperty(alias).Returns(property);
     }
+
+    private static MediaWithCrops WrapInCrops(IPublishedContent media) =>
+        new(media, Substitute.For<IPublishedValueFallback>(), new ImageCropperValue());
 
     [Fact]
     public void SupportedEditorAliases_ContainsMediaPicker3()
@@ -86,182 +117,84 @@ public class MediaPickerResolverTests
     }
 
     [Fact]
-    public void Resolve_SingleMediaWithCrops_ReturnsAbsoluteUrl()
+    public void Resolve_SingleMedia_ReturnsImageObject_WithAbsoluteUrl()
     {
-        var mediaContent = CreateMediaContent("/media/1234/image.jpg");
-        var publishedValueFallback = Substitute.For<IPublishedValueFallback>();
-        var localCrops = new ImageCropperValue();
-        var mediaWithCrops = new MediaWithCrops(mediaContent, publishedValueFallback, localCrops);
+        var media = CreateMediaContent("https://example.com/media/1234/image.jpg");
+        var mediaWithCrops = WrapInCrops(media);
 
         var property = Substitute.For<IPublishedProperty>();
         property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(mediaWithCrops);
 
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
+        var result = _sut.Resolve(CreateContext(property));
 
-        result.Should().Be("https://example.com/media/1234/image.jpg");
+        var image = result.Should().BeOfType<ImageObject>().Subject;
+        image.Url.First().Should().Be(new Uri("https://example.com/media/1234/image.jpg"));
     }
 
     [Fact]
-    public void Resolve_MultipleMediaWithCrops_ReturnsFirstItemUrl()
+    public void Resolve_MediaWithDimensions_SetsWidthAndHeight_AsQuantitativeValues()
     {
-        var mediaContent = CreateMediaContent("/media/1234/first.jpg");
-        var secondContent = CreateMediaContent("/media/5678/second.jpg");
-        var publishedValueFallback = Substitute.For<IPublishedValueFallback>();
-        var localCrops = new ImageCropperValue();
-        var mediaWithCrops = new MediaWithCrops(mediaContent, publishedValueFallback, localCrops);
-        var secondMediaWithCrops = new MediaWithCrops(secondContent, publishedValueFallback, localCrops);
-
-        var items = new List<MediaWithCrops> { mediaWithCrops, secondMediaWithCrops };
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(items);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().Be("https://example.com/media/1234/first.jpg");
-    }
-
-    [Fact]
-    public void Resolve_PublishedContent_ReturnsAbsoluteUrl()
-    {
-        var mediaContent = CreateMediaContent("/media/1234/image.jpg");
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(mediaContent);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().Be("https://example.com/media/1234/image.jpg");
-    }
-
-    [Fact]
-    public void Resolve_AbsoluteUrl_ReturnsAsIs()
-    {
-        var mediaContent = CreateMediaContent("https://cdn.example.com/image.jpg");
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(mediaContent);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().Be("https://cdn.example.com/image.jpg");
-    }
-
-    [Fact]
-    public void Resolve_ImageCropperValue_ExtractsSrc()
-    {
-        var mediaContent = CreateMediaContentWithCropper("/media/1234/cropped.jpg");
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(mediaContent);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().Be("https://example.com/media/1234/cropped.jpg");
-    }
-
-    [Fact]
-    public void Resolve_MediaWithNoUmbracoFile_ReturnsNull()
-    {
-        var mediaContent = Substitute.For<IPublishedContent>();
-        mediaContent.GetProperty("umbracoFile").Returns((IPublishedProperty?)null);
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(mediaContent);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public void Resolve_NoHttpContext_ReturnsRelativeUrl()
-    {
-        var noHttpAccessor = Substitute.For<IHttpContextAccessor>();
-        noHttpAccessor.HttpContext.Returns((HttpContext?)null);
-
-        var mediaContent = CreateMediaContent("/media/1234/image.jpg");
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(mediaContent);
-
-        var context = new PropertyResolverContext
-        {
-            Content = Substitute.For<IPublishedContent>(),
-            Mapping = new PropertyMapping { SchemaPropertyName = "Image" },
-            PropertyAlias = "image",
-            SchemaTypeRegistry = Substitute.For<ISchemaTypeRegistry>(),
-            MappingRepository = Substitute.For<ISchemaMappingRepository>(),
-            HttpContextAccessor = noHttpAccessor,
-            Property = property
-        };
-
-        var result = _sut.Resolve(context);
-
-        result.Should().Be("/media/1234/image.jpg");
-    }
-
-    [Fact]
-    public void Resolve_EmptyMultipleMediaList_ReturnsNull()
-    {
-        var items = new List<MediaWithCrops>();
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(items);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public void Resolve_MultipleMediaWithCrops_FirstItemDeletedMedia_ReturnsNull()
-    {
-        // When the first item in a multi-value picker has a deleted/broken media item
-        // (umbracoFile property missing), the resolver should return null gracefully
-        var deletedMedia = Substitute.For<IPublishedContent>();
-        deletedMedia.GetProperty("umbracoFile").Returns((IPublishedProperty?)null);
-
-        var publishedValueFallback = Substitute.For<IPublishedValueFallback>();
-        var localCrops = new ImageCropperValue();
-        var mediaWithCrops = new MediaWithCrops(deletedMedia, publishedValueFallback, localCrops);
-
-        var items = new List<MediaWithCrops> { mediaWithCrops };
-
-        var property = Substitute.For<IPublishedProperty>();
-        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(items);
-
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public void Resolve_UmbracoFilePropertyValueIsNull_ReturnsNull()
-    {
-        // When umbracoFile property exists on the media but its value is null
-        // (e.g., media item exists but the file has been removed from disk)
-        var umbracoFileProperty = Substitute.For<IPublishedProperty>();
-        umbracoFileProperty.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(null);
-
-        var media = Substitute.For<IPublishedContent>();
-        media.GetProperty("umbracoFile").Returns(umbracoFileProperty);
+        var media = CreateMediaContent("https://example.com/media/1234/image.jpg", width: 800, height: 600);
 
         var property = Substitute.For<IPublishedProperty>();
         property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(media);
 
-        var context = CreateContext(property);
-        var result = _sut.Resolve(context);
+        var result = _sut.Resolve(CreateContext(property));
+
+        var image = result.Should().BeOfType<ImageObject>().Subject;
+        var json = image.ToString();
+        json.Should().Contain("QuantitativeValue");
+        json.Should().Contain("width").And.Contain("800");
+        json.Should().Contain("height").And.Contain("600");
+    }
+
+    [Fact]
+    public void Resolve_MultipleMedia_ReturnsListOfImageObjects()
+    {
+        var first = CreateMediaContent("https://example.com/media/1/first.jpg");
+        var second = CreateMediaContent("https://example.com/media/2/second.jpg");
+        var items = new List<MediaWithCrops> { WrapInCrops(first), WrapInCrops(second) };
+
+        var property = Substitute.For<IPublishedProperty>();
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(items);
+
+        var result = _sut.Resolve(CreateContext(property));
+
+        var images = result.Should().BeOfType<List<ImageObject>>().Subject;
+        images.Should().HaveCount(2);
+        images[0].Url.First().Should().Be(new Uri("https://example.com/media/1/first.jpg"));
+        images[1].Url.First().Should().Be(new Uri("https://example.com/media/2/second.jpg"));
+    }
+
+    [Fact]
+    public void Resolve_DamagedMedia_ReturnsNull()
+    {
+        // url provider is not stubbed for this media, so GetMediaUrl returns null
+        var damaged = CreateDamagedMedia();
+
+        var property = Substitute.For<IPublishedProperty>();
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(damaged);
+
+        var result = _sut.Resolve(CreateContext(property));
 
         result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_FirstOfManyDamaged_SkipsAndReturnsRest()
+    {
+        var damaged = CreateDamagedMedia();
+        var healthy = CreateMediaContent("https://example.com/media/2/second.jpg");
+        var items = new List<MediaWithCrops> { WrapInCrops(damaged), WrapInCrops(healthy) };
+
+        var property = Substitute.For<IPublishedProperty>();
+        property.GetValue(Arg.Any<string?>(), Arg.Any<string?>()).Returns(items);
+
+        var result = _sut.Resolve(CreateContext(property));
+
+        // one damaged is dropped, leaving a single healthy image (returned unwrapped)
+        var image = result.Should().BeOfType<ImageObject>().Subject;
+        image.Url.First().Should().Be(new Uri("https://example.com/media/2/second.jpg"));
     }
 
     private PropertyResolverContext CreateContext(IPublishedProperty? property)

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/PropertyValueResolverFactoryTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/PropertyValueResolverFactoryTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Umbraco.Cms.Core.Routing;
 using Xunit;
 using Umbraco.Community.SchemeWeaver.Services.Resolvers;
 
@@ -43,7 +45,7 @@ public class PropertyValueResolverFactoryTests
         var resolvers = new IPropertyValueResolver[]
         {
             new DefaultPropertyValueResolver(),
-            new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance)
+            new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance, Substitute.For<IPublishedUrlProvider>())
         };
         var factory = new PropertyValueResolverFactory(resolvers);
 
@@ -148,7 +150,7 @@ public class PropertyValueResolverFactoryTests
         var resolvers = new IPropertyValueResolver[]
         {
             new DefaultPropertyValueResolver(),
-            new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance)
+            new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance, Substitute.For<IPublishedUrlProvider>())
         };
         var factory = new PropertyValueResolverFactory(resolvers);
 
@@ -163,7 +165,7 @@ public class PropertyValueResolverFactoryTests
         var resolvers = new IPropertyValueResolver[]
         {
             new DefaultPropertyValueResolver(),
-            new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance)
+            new MediaPickerResolver(NullLogger<MediaPickerResolver>.Instance, Substitute.For<IPublishedUrlProvider>())
         };
         var factory = new PropertyValueResolverFactory(resolvers);
 

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/SchemaPropertySetterTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/SchemaPropertySetterTests.cs
@@ -332,4 +332,74 @@ public class SchemaPropertySetterTests
     }
 
     #endregion
+
+    #region ImageObject media values (range-aware set + Uri downgrade)
+
+    [Fact]
+    public void SetPropertyValue_ImageObject_SetsArticleImage_AsImageObject()
+    {
+        // Article.Image is OneOrMany<Values<IImageObject, Uri>> — an ImageObject value must be
+        // stored as a nested ImageObject (not downgraded), because the target accepts IImageObject.
+        var article = new Article();
+        var image = new ImageObject { Url = new Uri("https://example.com/photo.jpg") };
+
+        SchemaPropertySetter.SetPropertyValue(article, "Image", image);
+
+        var jsonLd = article.ToString();
+        jsonLd.Should().Contain("ImageObject",
+            "an ImageObject set into an IImageObject-accepting target must remain an ImageObject");
+        jsonLd.Should().Contain("https://example.com/photo.jpg");
+    }
+
+    [Fact]
+    public void SetPropertyValue_ListOfImageObjects_SetsArticleImage_AsArray()
+    {
+        // A collection of ImageObjects into Article.Image must produce an array of ImageObjects.
+        var article = new Article();
+        var images = new List<ImageObject>
+        {
+            new() { Url = new Uri("https://example.com/one.jpg") },
+            new() { Url = new Uri("https://example.com/two.jpg") },
+        };
+
+        SchemaPropertySetter.SetPropertyValue(article, "Image", images);
+
+        var jsonLd = article.ToString();
+        jsonLd.Should().Contain("ImageObject");
+        jsonLd.Should().Contain("https://example.com/one.jpg");
+        jsonLd.Should().Contain("https://example.com/two.jpg");
+    }
+
+    [Fact]
+    public void SetPropertyValue_ImageObject_ToUriOnlyTarget_DowngradesToUrl()
+    {
+        // Organization.Url is OneOrMany<Uri> — accepts a Uri leaf but NOT IImageObject.
+        // An ImageObject value must be downgraded to its bare URL, not dropped or nested.
+        var org = new Organization();
+        var image = new ImageObject { Url = new Uri("https://example.com/logo.png") };
+
+        SchemaPropertySetter.SetPropertyValue(org, "Url", image);
+
+        var jsonLd = org.ToString();
+        jsonLd.Should().Contain("https://example.com/logo.png", "the bare URL must be stored");
+        jsonLd.Should().NotContain("ImageObject",
+            "a Uri-only target must receive the bare URL, not a nested ImageObject");
+    }
+
+    [Fact]
+    public void SetPropertyValue_ImageObject_ToLogo_SetsImageObject()
+    {
+        // Organization.Logo is OneOrMany<Values<IImageObject, Uri>> — accepts IImageObject, so
+        // an ImageObject must be kept as an ImageObject rather than downgraded.
+        var org = new Organization();
+        var image = new ImageObject { Url = new Uri("https://example.com/brand-logo.svg") };
+
+        SchemaPropertySetter.SetPropertyValue(org, "Logo", image);
+
+        var jsonLd = org.ToString();
+        jsonLd.Should().Contain("ImageObject");
+        jsonLd.Should().Contain("https://example.com/brand-logo.svg");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Media-picker properties mapped to an `ImageObject|Uri` schema property (`image`, `logo`) previously emitted nothing as an ImageObject and were fully dropped inside blocks.

## Fix
- New `Services/Media/MediaImageObjectFactory.Create(media, urlProvider)` builds a full `ImageObject` (absolute url + width/height `QuantitativeValue` + best-effort caption/name); `PrimaryImagePiece.Build` delegates to it.
- `MediaPickerResolver` returns `ImageObject` / `List<ImageObject>` / `null` (was a URL string); collects all picked media; injects `IPublishedUrlProvider`.
- `SchemaPropertySetter`: range-aware — keeps ImageObject(s) for `IImageObject` targets, downgrades to a bare `Uri` for Uri-only targets; the element-value path never `ToString()`s a media value (no raw `MediaWithCrops` JSON).
- `BlockContentResolver` routes block element props through the resolver factory so block media reaches `MediaPickerResolver` (static fallback kept when no factory).

Bumps `SchemeWeaverPackageVersion` 17.10.2→17.10.3 / 18.5.2→18.5.3. Both legs build; **881 unit tests green** (new coverage: resolver→ImageObject, setter keep/downgrade, block routing, null-media→no-raw-JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)