### PR TITLE
Quality sweep: clear all Code Quality findings, AI findings, and dependency alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ does not yet expose a runtime `addMockHandlers` API on
 once upstream ships the real API. See the harness README for the exact
 `git apply` command.
 
+## Error-handling policy
+JSON-LD generation and rendering must **never break the host page**. Resolvers, graph pieces, the tag helper and the Delivery API handlers deliberately catch **all** exceptions at their boundaries, log them (Debug/Warning), and degrade to omitting output. API endpoints funnel unexpected exceptions through `HandlesServerErrorAttribute`, which returns 500 with the frozen `{ error: "An unexpected error occurred whilst <operation>." }` body the frontend parses — do not replace it with ProblemDetails. CodeQL "generic catch clause" findings at these boundaries are dismissed as won't-fix **by policy**; do not "fix" them by narrowing the catch or letting exceptions propagate into rendered pages.
+
 ## Conventions
 - British English spelling
 - Package name is "SchemeWeaver" (intentional wordplay, not a typo)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -20,7 +20,7 @@ end to end.
 
 The quickest way to use the server with [Claude Code](https://claude.com/claude-code) — no clone,
 no build. The plugin is served straight from this GitHub repo and bundles a pre-built, self-contained
-server, so installation is two commands:
+server, so installation is three commands:
 
 ```text
 /plugin marketplace add EnjoyDigital/Umbraco.Community.Schemeweaver

--- a/src/Umbraco.Community.SchemeWeaver.AI/App_Plugins/SchemeWeaverAI/package-lock.json
+++ b/src/Umbraco.Community.SchemeWeaver.AI/App_Plugins/SchemeWeaverAI/package-lock.json
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.0.tgz",
-      "integrity": "sha512-OK9/R8WuujwgvnrDIPnEiIf6WnfUOi3GaEr6kIngqoI5FUQwYbeDKHE/frTVUl2A76ZQPCrMknHtPx6Gqtwf8Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -81,16 +81,16 @@
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.3.tgz",
-      "integrity": "sha512-UzGSDzh3QUhrnwl4atnHc2YqDO6KemYVEOwl1Ynowm/tcr0XlpdHOpyWr5UaWIJfiXTXdYRIC9k2Yxm19pcPzQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "js-yaml": "4.1.1"
+        "js-yaml": "4.2.0"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -100,16 +100,16 @@
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.98.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.98.2.tgz",
-      "integrity": "sha512-2nVJXH8tpFPGTBOhxyjEd1Jw0hsRqJqeTQW3kltAjVdSU4YWxeu97x5sgNOmsbsfeg6Dqz7Wfzs26walBOuswA==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.9.0",
-        "@hey-api/json-schema-ref-parser": "1.4.3",
-        "@hey-api/shared": "0.4.8",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "@lukeed/ms": "2.0.2",
@@ -132,21 +132,21 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.8.tgz",
-      "integrity": "sha512-29Pg2FB0UW20pplYgcfiQn1hQYpbZ9D2gdDJc7nDK3xh3pvHOTGP0v3R2ueFpFnw9GN1SRhIdhiVuAYWMDimjA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.9.0",
-        "@hey-api/json-schema-ref-parser": "1.4.3",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
         "cross-spawn": "7.0.6",
         "open": "11.0.0",
-        "semver": "7.8.2"
+        "semver": "7.8.4"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -1370,9 +1370,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -1590,10 +1590,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1944,17 +1954,6 @@
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/monaco-editor/node_modules/marked": {
@@ -2465,9 +2464,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "peer": true,

--- a/src/Umbraco.Community.SchemeWeaver.AI/App_Plugins/SchemeWeaverAI/package.json
+++ b/src/Umbraco.Community.SchemeWeaver.AI/App_Plugins/SchemeWeaverAI/package.json
@@ -22,5 +22,10 @@
     "@types/node": "^20.10.6",
     "typescript": "^5.3.3",
     "vite": "^8.0.8"
+  },
+  "overrides": {
+    "monaco-editor": {
+      "dompurify": "^3.4.8"
+    }
   }
 }

--- a/src/Umbraco.Community.SchemeWeaver.AI/Services/AISchemaMapper.cs
+++ b/src/Umbraco.Community.SchemeWeaver.AI/Services/AISchemaMapper.cs
@@ -426,20 +426,17 @@ public class AISchemaMapper : IAISchemaMapper
         }
 
         // 3. Completeness: list every remaining schema property as an unmapped placeholder.
-        foreach (var prop in schemaProperties)
+        foreach (var prop in schemaProperties.Where(p => !merged.ContainsKey(p.Name)))
         {
-            if (!merged.ContainsKey(prop.Name))
+            merged[prop.Name] = new PropertyMappingSuggestion
             {
-                merged[prop.Name] = new PropertyMappingSuggestion
-                {
-                    SchemaPropertyName = prop.Name,
-                    SchemaPropertyType = prop.PropertyType,
-                    AcceptedTypes = prop.AcceptedTypes,
-                    IsComplexType = prop.IsComplexType,
-                    Confidence = 0,
-                    IsAutoMapped = false,
-                };
-            }
+                SchemaPropertyName = prop.Name,
+                SchemaPropertyType = prop.PropertyType,
+                AcceptedTypes = prop.AcceptedTypes,
+                IsComplexType = prop.IsComplexType,
+                Confidence = 0,
+                IsAutoMapped = false,
+            };
         }
 
         return merged.Values

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/dist/index.js
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/dist/index.js
@@ -18,7 +18,11 @@ var __require = /* @__PURE__ */ ((x) => typeof require$1 !== "undefined" ? requi
   throw Error('Dynamic require of "' + x + '" is not supported');
 });
 var __commonJS = (cb, mod) => function __require2() {
-  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  try {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  } catch (e) {
+    throw mod = 0, e;
+  }
 };
 var __export = (target, all) => {
   for (var name in all)

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/package-lock.json
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco-community/schemeweaver-mcp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco-community/schemeweaver-mcp",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -33,7 +33,7 @@
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
-        "undici": "^7.0.0"
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -696,9 +696,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -747,9 +747,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -764,9 +764,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -832,9 +832,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -849,9 +849,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -883,9 +883,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -917,9 +917,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1002,9 +1002,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1019,11 +1019,28 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
       ],
       "dev": true,
       "license": "MIT",
@@ -1729,6 +1746,490 @@
         "typedoc": "^0.28.14"
       }
     },
+    "node_modules/@orval/core/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@orval/core/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/@orval/fetch": {
       "version": "7.21.0",
       "dev": true,
@@ -2146,6 +2647,14 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "dev": true,
@@ -2363,20 +2872,23 @@
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.10.1",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.5.tgz",
+      "integrity": "sha512-vDCd0NJ93715bcUpZZ5vNHiyxd4cgHF6tuXsDiXOXKAByg+I1fR5/dMijEo6Ce1Lz95a+RZ22JKYhF1YuzVvuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@scarf/scarf": "^1.4.0",
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.1",
-        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-core": "^1.23.0",
         "@stoplight/spectral-formats": "^1.8.1",
         "@stoplight/spectral-runtime": "^1.1.2",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.1",
-        "lodash": "~4.17.21",
+        "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -2398,11 +2910,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@stoplight/spectral-functions/node_modules/lodash": {
-      "version": "4.17.23",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@stoplight/spectral-parsers": {
       "version": "1.0.5",
@@ -3965,7 +4472,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3976,49 +4485,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
-      }
-    },
-    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -5957,7 +6449,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6955,8 +7449,20 @@
       }
     },
     "node_modules/orval/node_modules/js-yaml": {
-      "version": "4.1.1",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8705,486 +9211,6 @@
         }
       }
     },
-    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsup/node_modules/esbuild": {
-      "version": "0.27.7",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
     "node_modules/tsup/node_modules/source-map": {
       "version": "0.7.6",
       "dev": true,
@@ -9493,7 +9519,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/package.json
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/package.json
@@ -58,7 +58,16 @@
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "tsup": "^8.4.0",
-    "undici": "^7.0.0",
+    "undici": "^7.28.0",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "@stoplight/spectral-functions": "^1.10.5",
+    "orval": {
+      "js-yaml": "^4.2.0"
+    },
+    "tsup": {
+      "esbuild": "^0.28.1"
+    }
   }
 }

--- a/src/Umbraco.Community.SchemeWeaver.Mcp/package.json
+++ b/src/Umbraco.Community.SchemeWeaver.Mcp/package.json
@@ -69,5 +69,8 @@
     "tsup": {
       "esbuild": "^0.28.1"
     }
+  },
+  "scarf": {
+    "enabled": false
   }
 }

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/AutomotiveListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/AutomotiveListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/BlogListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/BlogListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ContactPage.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ContactPage.cshtml
@@ -29,7 +29,7 @@
                 @Model.AddressLocality @Model.PostalCode
             </dd>
         }
-        @if (Model.OpeningHours?.Any() == true)
+        @if (Model.OpeningHours?.Any() is true)
         {
             <dt>Opening Hours</dt>
             <dd>@Model.OpeningHours</dd>

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/CreativeListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/CreativeListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/DiningListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/DiningListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/EducationListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/EducationListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/EntertainmentListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/EntertainmentListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/EventListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/EventListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/GymPage.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/GymPage.cshtml
@@ -22,7 +22,7 @@
             <dt>Telephone</dt>
             <dd>@Model.Telephone</dd>
         }
-        @if (Model.OpeningHours?.Any() == true)
+        @if (Model.OpeningHours?.Any() is true)
         {
             <dt>Opening Hours</dt>
             <dd>@Model.OpeningHours</dd>

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/HealthcareListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/HealthcareListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/OrganisationListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/OrganisationListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/PlacesListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/PlacesListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ProductListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ProductListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ProductPage.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ProductPage.cshtml
@@ -45,7 +45,7 @@
     </div>
 }
 
-@if (Model.Reviews?.Any() == true)
+@if (Model.Reviews?.Any() is true)
 {
     <h2>Customer Reviews</h2>
     @foreach (var block in Model.Reviews)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/PropertyListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/PropertyListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/RecipeListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/RecipeListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/RecipePage.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/RecipePage.cshtml
@@ -65,7 +65,7 @@
     <img src="@Model.RecipeImage.MediaUrl()" alt="@Model.RecipeImage.Name" class="content-image" />
 }
 
-@if (Model.Ingredients?.Any() == true)
+@if (Model.Ingredients?.Any() is true)
 {
     <div class="card">
         <h2>Ingredients</h2>
@@ -82,7 +82,7 @@
     </div>
 }
 
-@if (Model.Instructions?.Any() == true)
+@if (Model.Instructions?.Any() is true)
 {
     <div class="card">
         <h2>Instructions</h2>

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/RestaurantPage.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/RestaurantPage.cshtml
@@ -102,7 +102,7 @@
     </div>
 }
 
-@if (Model.OpeningHours?.Any() == true)
+@if (Model.OpeningHours?.Any() is true)
 {
     <div class="card">
         <h2>Opening Hours</h2>

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ServicesListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ServicesListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ShopsListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/ShopsListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.TestHost/Views/TravelListing.cshtml
+++ b/src/Umbraco.Community.SchemeWeaver.TestHost/Views/TravelListing.cshtml
@@ -3,7 +3,7 @@
     Layout = "Master.cshtml";
     var categories = Model.Children()?.Where(c => c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
     var items = Model.Children()?.Where(c => !c.ContentType.Alias.EndsWith("Listing")) ?? Enumerable.Empty<IPublishedContent>();
-    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") == true;
+    var parentIsListing = Model.Parent()?.ContentType.Alias.EndsWith("Listing") is true;
 }
 
 @if (parentIsListing)

--- a/src/Umbraco.Community.SchemeWeaver.uSync/IMappingFileWriter.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/IMappingFileWriter.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace Umbraco.Community.SchemeWeaver.uSync;
 
@@ -17,19 +18,49 @@ public interface IMappingFileWriter
     void Delete(string folder, string alias);
 }
 
-/// <summary>Default <see cref="IMappingFileWriter"/> that writes to the local file system.</summary>
+/// <summary>
+/// Default <see cref="IMappingFileWriter"/> that writes to the local file system.
+/// Aliases that are not plain file names (path separators, traversal segments, invalid
+/// characters) are REJECTED rather than sanitised — a transforming sanitiser would break the
+/// alias↔filename bijection that filename-keyed drift detection relies on.
+/// </summary>
 public class MappingFileWriter : IMappingFileWriter
 {
+    private readonly ILogger<MappingFileWriter>? _logger;
+
+    public MappingFileWriter(ILogger<MappingFileWriter>? logger = null)
+    {
+        _logger = logger;
+    }
+
     public void Write(string folder, string alias, XElement xml)
     {
+        if (!IsSafeAlias(alias))
+        {
+            _logger?.LogWarning("Refusing to write uSync mapping file for unsafe alias {Alias}", alias);
+            return;
+        }
+
         Directory.CreateDirectory(folder);
-        xml.Save(Path.Combine(folder, $"{alias}.config"));
+        xml.Save(Path.Join(folder, $"{alias}.config"));
     }
 
     public void Delete(string folder, string alias)
     {
-        var path = Path.Combine(folder, $"{alias}.config");
+        if (!IsSafeAlias(alias))
+        {
+            _logger?.LogWarning("Refusing to delete uSync mapping file for unsafe alias {Alias}", alias);
+            return;
+        }
+
+        var path = Path.Join(folder, $"{alias}.config");
         if (File.Exists(path))
             File.Delete(path);
     }
+
+    /// <summary>True when the alias maps 1:1 to a plain file name inside the mappings folder.</summary>
+    private static bool IsSafeAlias(string alias)
+        => !string.IsNullOrEmpty(alias)
+           && Path.GetFileName(alias) == alias
+           && alias.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }

--- a/src/Umbraco.Community.SchemeWeaver.uSync/IMappingFileWriter.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/IMappingFileWriter.cs
@@ -11,11 +11,17 @@ namespace Umbraco.Community.SchemeWeaver.uSync;
 /// </summary>
 public interface IMappingFileWriter
 {
-    /// <summary>Writes <paramref name="xml"/> to <c>{folder}/{alias}.config</c>, creating the folder if needed.</summary>
-    void Write(string folder, string alias, XElement xml);
+    /// <summary>
+    /// Writes <paramref name="xml"/> to <c>{folder}/{alias}.config</c>, creating the folder if
+    /// needed. Returns false when the alias is refused as unsafe (not a plain file name).
+    /// </summary>
+    bool Write(string folder, string alias, XElement xml);
 
-    /// <summary>Removes <c>{folder}/{alias}.config</c> if it exists.</summary>
-    void Delete(string folder, string alias);
+    /// <summary>
+    /// Removes <c>{folder}/{alias}.config</c> if it exists. Returns false when the alias is
+    /// refused as unsafe (not a plain file name).
+    /// </summary>
+    bool Delete(string folder, string alias);
 }
 
 /// <summary>
@@ -33,34 +39,30 @@ public class MappingFileWriter : IMappingFileWriter
         _logger = logger;
     }
 
-    public void Write(string folder, string alias, XElement xml)
+    public bool Write(string folder, string alias, XElement xml)
     {
-        if (!IsSafeAlias(alias))
+        if (!SchemeWeaverMappingPaths.IsSafeAlias(alias))
         {
             _logger?.LogWarning("Refusing to write uSync mapping file for unsafe alias {Alias}", alias);
-            return;
+            return false;
         }
 
         Directory.CreateDirectory(folder);
         xml.Save(Path.Join(folder, $"{alias}.config"));
+        return true;
     }
 
-    public void Delete(string folder, string alias)
+    public bool Delete(string folder, string alias)
     {
-        if (!IsSafeAlias(alias))
+        if (!SchemeWeaverMappingPaths.IsSafeAlias(alias))
         {
             _logger?.LogWarning("Refusing to delete uSync mapping file for unsafe alias {Alias}", alias);
-            return;
+            return false;
         }
 
         var path = Path.Join(folder, $"{alias}.config");
         if (File.Exists(path))
             File.Delete(path);
+        return true;
     }
-
-    /// <summary>True when the alias maps 1:1 to a plain file name inside the mappings folder.</summary>
-    private static bool IsSafeAlias(string alias)
-        => !string.IsNullOrEmpty(alias)
-           && Path.GetFileName(alias) == alias
-           && alias.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }

--- a/src/Umbraco.Community.SchemeWeaver.uSync/SchemaMappingImportComponent.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/SchemaMappingImportComponent.cs
@@ -52,12 +52,12 @@ public class SchemaMappingImportNotificationHandler : INotificationAsyncHandler<
         // folder to actually contain mapping files so an empty "v18" (e.g. created by
         // an in-place upgrade) cannot shadow a populated legacy "v17".
         var mappingsFolder = new[] { "v18", "v17" }
-            .Select(version => Path.Combine(_hostEnvironment.ContentRootPath, "uSync", version, "SchemeWeaverMappings"))
+            .Select(version => Path.Join(_hostEnvironment.ContentRootPath, "uSync", version, "SchemeWeaverMappings"))
             .FirstOrDefault(path => Directory.Exists(path) && Directory.EnumerateFiles(path, "*.config", SearchOption.AllDirectories).Any());
 
         if (mappingsFolder is null)
         {
-            var defaultPath = Path.Combine(_hostEnvironment.ContentRootPath, "uSync", "v18", "SchemeWeaverMappings");
+            var defaultPath = Path.Join(_hostEnvironment.ContentRootPath, "uSync", "v18", "SchemeWeaverMappings");
             _logger.LogDebug("No SchemeWeaverMappings folder found (looked under v18/v17, e.g. {Path}) — skipping import", defaultPath);
             return;
         }

--- a/src/Umbraco.Community.SchemeWeaver.uSync/SchemeWeaverMappingPaths.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/SchemeWeaverMappingPaths.cs
@@ -26,9 +26,9 @@ internal static class SchemeWeaverMappingPaths
     /// </summary>
     public static string ResolveWriteFolder(string contentRootPath)
     {
-        var uSyncRoot = Path.Combine(contentRootPath, RootFolderName);
-        var version = Versions.FirstOrDefault(v => Directory.Exists(Path.Combine(uSyncRoot, v)))
+        var uSyncRoot = Path.Join(contentRootPath, RootFolderName);
+        var version = Versions.FirstOrDefault(v => Directory.Exists(Path.Join(uSyncRoot, v)))
                       ?? Versions[0];
-        return Path.Combine(uSyncRoot, version, MappingsFolderName);
+        return Path.Join(uSyncRoot, version, MappingsFolderName);
     }
 }

--- a/src/Umbraco.Community.SchemeWeaver.uSync/SchemeWeaverMappingPaths.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/SchemeWeaverMappingPaths.cs
@@ -31,4 +31,15 @@ internal static class SchemeWeaverMappingPaths
                       ?? Versions[0];
         return Path.Join(uSyncRoot, version, MappingsFolderName);
     }
+
+    /// <summary>
+    /// True when the alias maps 1:1 to a plain file name inside the mappings folder — the
+    /// invariant that filename-keyed drift detection relies on. Aliases failing this are
+    /// refused by <see cref="MappingFileWriter"/> and reported as db-only by drift, so the
+    /// two sides must share this check.
+    /// </summary>
+    public static bool IsSafeAlias(string alias)
+        => !string.IsNullOrEmpty(alias)
+           && Path.GetFileName(alias) == alias
+           && alias.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }

--- a/src/Umbraco.Community.SchemeWeaver.uSync/SchemeWeaverMappingPaths.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/SchemeWeaverMappingPaths.cs
@@ -36,10 +36,13 @@ internal static class SchemeWeaverMappingPaths
     /// True when the alias maps 1:1 to a plain file name inside the mappings folder — the
     /// invariant that filename-keyed drift detection relies on. Aliases failing this are
     /// refused by <see cref="MappingFileWriter"/> and reported as db-only by drift, so the
-    /// two sides must share this check.
+    /// two sides must share this check. Both separators are rejected on every OS: uSync
+    /// folders travel between machines, so an alias that is a harmless file name on Linux
+    /// (backslash is legal there) must not become a traversal when imported on Windows.
     /// </summary>
     public static bool IsSafeAlias(string alias)
         => !string.IsNullOrEmpty(alias)
+           && alias.IndexOfAny(['/', '\\']) < 0
            && Path.GetFileName(alias) == alias
            && alias.IndexOfAny(Path.GetInvalidFileNameChars()) < 0;
 }

--- a/src/Umbraco.Community.SchemeWeaver.uSync/USyncMappingDriftReporter.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/USyncMappingDriftReporter.cs
@@ -126,6 +126,11 @@ public sealed class USyncMappingDriftReporter : IMappingDriftReporter
         var mapping = repository.GetByContentTypeAlias(contentTypeAlias);
         if (mapping is null)
         {
+            // An unsafe alias never has a legitimate file (the writer refuses it), so don't
+            // probe the disk with it.
+            if (!SchemeWeaverMappingPaths.IsSafeAlias(contentTypeAlias))
+                return MappingDriftStatus.DbOnly;
+
             var path = Path.Join(folder, $"{contentTypeAlias}.config");
             return File.Exists(path) ? MappingDriftStatus.DiskOnly : MappingDriftStatus.DbOnly;
         }
@@ -139,6 +144,11 @@ public sealed class USyncMappingDriftReporter : IMappingDriftReporter
     /// </summary>
     private string Compare(SchemaMapping mapping, string folder, SchemaMappingSerializer? serializer)
     {
+        // Mirrors MappingFileWriter's refusal: an unsafe alias has no on-disk counterpart by
+        // definition, so it is db-only — and must not be used to probe outside the folder.
+        if (!SchemeWeaverMappingPaths.IsSafeAlias(mapping.ContentTypeAlias))
+            return MappingDriftStatus.DbOnly;
+
         var path = Path.Join(folder, $"{mapping.ContentTypeAlias}.config");
         if (!File.Exists(path))
             return MappingDriftStatus.DbOnly;

--- a/src/Umbraco.Community.SchemeWeaver.uSync/USyncMappingDriftReporter.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/USyncMappingDriftReporter.cs
@@ -126,7 +126,7 @@ public sealed class USyncMappingDriftReporter : IMappingDriftReporter
         var mapping = repository.GetByContentTypeAlias(contentTypeAlias);
         if (mapping is null)
         {
-            var path = Path.Combine(folder, $"{contentTypeAlias}.config");
+            var path = Path.Join(folder, $"{contentTypeAlias}.config");
             return File.Exists(path) ? MappingDriftStatus.DiskOnly : MappingDriftStatus.DbOnly;
         }
 
@@ -139,7 +139,7 @@ public sealed class USyncMappingDriftReporter : IMappingDriftReporter
     /// </summary>
     private string Compare(SchemaMapping mapping, string folder, SchemaMappingSerializer? serializer)
     {
-        var path = Path.Combine(folder, $"{mapping.ContentTypeAlias}.config");
+        var path = Path.Join(folder, $"{mapping.ContentTypeAlias}.config");
         if (!File.Exists(path))
             return MappingDriftStatus.DbOnly;
 

--- a/src/Umbraco.Community.SchemeWeaver.uSync/USyncMappingExporter.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/USyncMappingExporter.cs
@@ -69,8 +69,15 @@ public sealed class USyncMappingExporter : IMappingExporter
                     continue;
                 }
 
-                _fileWriter.Write(folder, mapping.ContentTypeAlias, attempt.Item);
-                items.Add(new MappingExportItemDto { Alias = mapping.ContentTypeAlias, Written = true });
+                var written = _fileWriter.Write(folder, mapping.ContentTypeAlias, attempt.Item);
+                items.Add(written
+                    ? new MappingExportItemDto { Alias = mapping.ContentTypeAlias, Written = true }
+                    : new MappingExportItemDto
+                    {
+                        Alias = mapping.ContentTypeAlias,
+                        Written = false,
+                        Error = "Alias is not a safe file name; write refused.",
+                    });
             }
             catch (Exception ex)
             {

--- a/src/Umbraco.Community.SchemeWeaver/App_Plugins/SchemeWeaver/package-lock.json
+++ b/src/Umbraco.Community.SchemeWeaver/App_Plugins/SchemeWeaver/package-lock.json
@@ -55,21 +55,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.0.tgz",
-      "integrity": "sha512-OK9/R8WuujwgvnrDIPnEiIf6WnfUOi3GaEr6kIngqoI5FUQwYbeDKHE/frTVUl2A76ZQPCrMknHtPx6Gqtwf8Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -579,16 +579,16 @@
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.3.tgz",
-      "integrity": "sha512-UzGSDzh3QUhrnwl4atnHc2YqDO6KemYVEOwl1Ynowm/tcr0XlpdHOpyWr5UaWIJfiXTXdYRIC9k2Yxm19pcPzQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "js-yaml": "4.1.1"
+        "js-yaml": "4.2.0"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -598,16 +598,16 @@
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.98.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.98.2.tgz",
-      "integrity": "sha512-2nVJXH8tpFPGTBOhxyjEd1Jw0hsRqJqeTQW3kltAjVdSU4YWxeu97x5sgNOmsbsfeg6Dqz7Wfzs26walBOuswA==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.9.0",
-        "@hey-api/json-schema-ref-parser": "1.4.3",
-        "@hey-api/shared": "0.4.8",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "@lukeed/ms": "2.0.2",
@@ -630,21 +630,21 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.8.tgz",
-      "integrity": "sha512-29Pg2FB0UW20pplYgcfiQn1hQYpbZ9D2gdDJc7nDK3xh3pvHOTGP0v3R2ueFpFnw9GN1SRhIdhiVuAYWMDimjA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.9.0",
-        "@hey-api/json-schema-ref-parser": "1.4.3",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
         "cross-spawn": "7.0.6",
         "open": "11.0.0",
-        "semver": "7.8.2"
+        "semver": "7.8.4"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -888,14 +888,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1083,9 +1083,9 @@
       "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -1134,9 +1134,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -1151,9 +1151,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -1168,9 +1168,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -1202,9 +1202,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -1219,9 +1219,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -1236,9 +1236,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -1253,9 +1253,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -1297,18 +1297,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -1323,9 +1323,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2281,9 +2281,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3419,9 +3419,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4250,9 +4250,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -4603,9 +4603,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -4866,9 +4866,9 @@
       }
     },
     "node_modules/giget": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
-      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5159,9 +5159,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5484,10 +5484,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5905,10 +5915,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6021,16 +6041,26 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -6307,9 +6337,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -6744,9 +6774,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -6764,7 +6794,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7128,9 +7158,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7150,13 +7180,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -7405,14 +7436,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -7421,21 +7452,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/rollup": {
@@ -7587,9 +7618,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7638,15 +7669,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -7995,9 +8026,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8327,17 +8358,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8353,7 +8384,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -8513,9 +8544,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/Umbraco.Community.SchemeWeaver/Controllers/HandlesServerErrorAttribute.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Controllers/HandlesServerErrorAttribute.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Umbraco.Community.SchemeWeaver.Controllers;
+
+/// <summary>
+/// Funnels any unhandled exception from a SchemeWeaver API action into the frozen wire contract:
+/// HTTP 500 with a body of <c>{ error: "An unexpected error occurred whilst &lt;operation&gt;." }</c>.
+/// The frontend (<c>schemeweaver.server-data-source.ts</c>) parses that exact shape, so this must
+/// NOT be changed to ProblemDetails. Route values and the query string are logged so the
+/// structured per-request parameters the old per-action catch blocks captured are preserved.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class HandlesServerErrorAttribute : ExceptionFilterAttribute
+{
+    private readonly string _operation;
+
+    public HandlesServerErrorAttribute(string operation)
+    {
+        _operation = operation;
+    }
+
+    public override void OnException(ExceptionContext context)
+    {
+        var logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILogger<SchemeWeaverApiController>>();
+
+        logger.LogError(
+            context.Exception,
+            "SchemeWeaver API failure whilst {Operation} ({Action}; route {RouteValues}; query {QueryString})",
+            _operation,
+            context.ActionDescriptor.DisplayName,
+            context.RouteData.Values,
+            context.HttpContext.Request.QueryString);
+
+        context.Result = new ObjectResult(new { error = $"An unexpected error occurred whilst {_operation}." })
+        {
+            StatusCode = StatusCodes.Status500InternalServerError,
+        };
+        context.ExceptionHandled = true;
+    }
+}

--- a/src/Umbraco.Community.SchemeWeaver/Controllers/SchemeWeaverApiController.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Controllers/SchemeWeaverApiController.cs
@@ -17,6 +17,9 @@ namespace Umbraco.Community.SchemeWeaver.Controllers;
 
 /// <summary>
 /// Management API controller for SchemeWeaver backoffice operations.
+/// Unexpected exceptions are funnelled through <see cref="HandlesServerErrorAttribute"/>
+/// (500 + <c>{ error }</c> body); enumerable results are materialised inside the action so a
+/// lazily-throwing sequence cannot fail during serialisation, after the filter has run.
 /// </summary>
 [Route("umbraco/management/api/v1/schemeweaver")]
 [ApiExplorerSettings(GroupName = SchemeWeaverConstants.PackageName)]
@@ -68,44 +71,30 @@ public class SchemeWeaverApiController : ControllerBase
 
     [HttpGet("schema-types")]
     [ProducesResponseType(typeof(IEnumerable<SchemaTypeInfo>), StatusCodes.Status200OK)]
+    [HandlesServerError("retrieving schema types")]
     public IActionResult GetSchemaTypes([FromQuery] string? search = null)
     {
-        try
-        {
-            var types = string.IsNullOrWhiteSpace(search)
-                ? _service.GetSchemaTypes()
-                : _service.SearchSchemaTypes(search);
+        var types = string.IsNullOrWhiteSpace(search)
+            ? _service.GetSchemaTypes()
+            : _service.SearchSchemaTypes(search);
 
-            return Ok(types);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve schema types");
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving schema types." });
-        }
+        return Ok(types.ToList());
     }
 
     [HttpGet("schema-types/{name}/properties")]
     [ProducesResponseType(typeof(IEnumerable<SchemaPropertyInfo>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(IEnumerable<RankedSchemaPropertyInfo>), StatusCodes.Status200OK)]
+    [HandlesServerError("retrieving schema type properties")]
     public IActionResult GetSchemaTypeProperties(string name, [FromQuery] bool ranked = false)
     {
-        try
+        if (ranked)
         {
-            if (ranked)
-            {
-                var rankedResults = _schemaAutoMapper.RankSchemaProperties(name);
-                return Ok(rankedResults);
-            }
+            var rankedResults = _schemaAutoMapper.RankSchemaProperties(name);
+            return Ok(rankedResults);
+        }
 
-            var properties = _service.GetSchemaProperties(name);
-            return Ok(properties);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve properties for schema type {SchemaTypeName}", name);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving schema type properties." });
-        }
+        var properties = _service.GetSchemaProperties(name);
+        return Ok(properties);
     }
 
     #endregion
@@ -114,109 +103,82 @@ public class SchemeWeaverApiController : ControllerBase
 
     [HttpGet("content-types")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [HandlesServerError("retrieving content types")]
     public IActionResult GetContentTypes()
     {
-        try
-        {
-            var contentTypes = _contentTypeService.GetAll()
-                .Select(ct => new
-                {
-                    ct.Alias,
-                    ct.Name,
-                    ct.Key,
-                    PropertyCount = ct.CompositionPropertyTypes.Count()
-                })
-                .OrderBy(ct => ct.Name);
+        var contentTypes = _contentTypeService.GetAll()
+            .Select(ct => new
+            {
+                ct.Alias,
+                ct.Name,
+                ct.Key,
+                PropertyCount = ct.CompositionPropertyTypes.Count()
+            })
+            .OrderBy(ct => ct.Name)
+            .ToList();
 
-            return Ok(contentTypes);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve content types");
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving content types." });
-        }
+        return Ok(contentTypes);
     }
 
     [HttpGet("content-types/{alias}/properties")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [HandlesServerError("retrieving content type properties")]
     public async Task<IActionResult> GetContentTypeProperties(string alias)
     {
-        try
+        var contentType = _contentTypeService.Get(alias);
+        if (contentType == null) return NotFound();
+
+        // Built-in node properties first (no real data type, so no value schema), then the
+        // editor-defined properties. Uses CompositionPropertyTypes (not PropertyTypes) so
+        // properties inherited from compositions — e.g. a shared "Hero" tab — are included,
+        // each enriched with its Umbraco 17.4+ value JSON Schema (the actual shape its stored
+        // value takes) when available, else null on older hosts.
+        var properties = new List<object>();
+
+        foreach (var bp in SchemeWeaverConstants.BuiltInProperties.All)
         {
-            var contentType = _contentTypeService.Get(alias);
-            if (contentType == null) return NotFound();
-
-            // Built-in node properties first (no real data type, so no value schema), then the
-            // editor-defined properties. Uses CompositionPropertyTypes (not PropertyTypes) so
-            // properties inherited from compositions — e.g. a shared "Hero" tab — are included,
-            // each enriched with its Umbraco 17.4+ value JSON Schema (the actual shape its stored
-            // value takes) when available, else null on older hosts.
-            var properties = new List<object>();
-
-            foreach (var bp in SchemeWeaverConstants.BuiltInProperties.All)
+            properties.Add(new
             {
-                properties.Add(new
-                {
-                    Alias = bp.Alias,
-                    Name = bp.DisplayName,
-                    EditorAlias = bp.EditorAlias,
-                    Description = (string?)null,
-                    ValueSchema = (string?)null,
-                });
-            }
-
-            foreach (var pt in contentType.CompositionPropertyTypes)
-            {
-                var valueSchema = await _valueSchemaService.GetDataTypeValueSchemaAsync(pt.DataTypeKey).ConfigureAwait(false);
-                properties.Add(new
-                {
-                    Alias = pt.Alias,
-                    Name = pt.Name,
-                    EditorAlias = pt.PropertyEditorAlias,
-                    Description = pt.Description,
-                    ValueSchema = valueSchema,
-                });
-            }
-
-            return Ok(properties);
+                Alias = bp.Alias,
+                Name = bp.DisplayName,
+                EditorAlias = bp.EditorAlias,
+                Description = (string?)null,
+                ValueSchema = (string?)null,
+            });
         }
-        catch (Exception ex)
+
+        foreach (var pt in contentType.CompositionPropertyTypes)
         {
-            _logger.LogError(ex, "Failed to retrieve properties for content type {ContentTypeAlias}", alias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving content type properties." });
+            var valueSchema = await _valueSchemaService.GetDataTypeValueSchemaAsync(pt.DataTypeKey).ConfigureAwait(false);
+            properties.Add(new
+            {
+                Alias = pt.Alias,
+                Name = pt.Name,
+                EditorAlias = pt.PropertyEditorAlias,
+                Description = pt.Description,
+                ValueSchema = valueSchema,
+            });
         }
+
+        return Ok(properties);
     }
 
     [HttpGet("content-types/{contentTypeAlias}/properties/{propertyAlias}/block-types")]
     [ProducesResponseType(typeof(IEnumerable<BlockElementTypeInfo>), StatusCodes.Status200OK)]
+    [HandlesServerError("retrieving block element types")]
     public async Task<IActionResult> GetBlockElementTypes(string contentTypeAlias, string propertyAlias)
     {
-        try
-        {
-            var blockTypes = await _service.GetBlockElementTypesAsync(contentTypeAlias, propertyAlias).ConfigureAwait(false);
-            return Ok(blockTypes);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve block element types for {ContentTypeAlias}/{PropertyAlias}", contentTypeAlias, propertyAlias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving block element types." });
-        }
+        var blockTypes = await _service.GetBlockElementTypesAsync(contentTypeAlias, propertyAlias).ConfigureAwait(false);
+        return Ok(blockTypes);
     }
 
     [HttpPost("content-types/{contentTypeAlias}/properties/{propertyAlias}/block-suggest")]
     [ProducesResponseType(typeof(IEnumerable<BlockMappingSuggestion>), StatusCodes.Status200OK)]
+    [HandlesServerError("suggesting block mappings")]
     public async Task<IActionResult> SuggestBlockMappings(string contentTypeAlias, string propertyAlias)
     {
-        try
-        {
-            var suggestions = await _service.SuggestBlockMappingsAsync(contentTypeAlias, propertyAlias).ConfigureAwait(false);
-            return Ok(suggestions);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to suggest block mappings for {ContentTypeAlias}/{PropertyAlias}", contentTypeAlias, propertyAlias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst suggesting block mappings." });
-        }
+        var suggestions = await _service.SuggestBlockMappingsAsync(contentTypeAlias, propertyAlias).ConfigureAwait(false);
+        return Ok(suggestions);
     }
 
     #endregion
@@ -225,164 +187,110 @@ public class SchemeWeaverApiController : ControllerBase
 
     [HttpGet("mappings")]
     [ProducesResponseType(typeof(IEnumerable<SchemaMappingDto>), StatusCodes.Status200OK)]
+    [HandlesServerError("retrieving schema mappings")]
     public IActionResult GetMappings()
     {
-        try
-        {
-            return Ok(_service.GetAllMappings());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve schema mappings");
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving schema mappings." });
-        }
+        // GetAllMappings is lazy (per-item drift/reachability probes) — materialise so a
+        // throwing probe surfaces here, inside the exception filter's reach.
+        return Ok(_service.GetAllMappings().ToList());
     }
 
     [HttpGet("mappings/{contentTypeAlias}")]
     [ProducesResponseType(typeof(SchemaMappingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HandlesServerError("retrieving the schema mapping")]
     public IActionResult GetMapping(string contentTypeAlias)
     {
-        try
-        {
-            var mapping = _service.GetMapping(contentTypeAlias);
-            if (mapping == null) return NotFound();
-            return Ok(mapping);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to retrieve mapping for content type {ContentTypeAlias}", contentTypeAlias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst retrieving the schema mapping." });
-        }
+        var mapping = _service.GetMapping(contentTypeAlias);
+        if (mapping == null) return NotFound();
+        return Ok(mapping);
     }
 
     [HttpPost("mappings")]
     [ProducesResponseType(typeof(SchemaMappingDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [HandlesServerError("saving the schema mapping")]
     public IActionResult SaveMapping([FromBody] SchemaMappingDto dto)
     {
-        try
-        {
-            if (string.IsNullOrWhiteSpace(dto.ContentTypeAlias))
-                return BadRequest("ContentTypeAlias is required.");
+        if (string.IsNullOrWhiteSpace(dto.ContentTypeAlias))
+            return BadRequest("ContentTypeAlias is required.");
 
-            if (string.IsNullOrWhiteSpace(dto.SchemaTypeName))
-                return BadRequest("SchemaTypeName is required.");
+        if (string.IsNullOrWhiteSpace(dto.SchemaTypeName))
+            return BadRequest("SchemaTypeName is required.");
 
-            var saved = _service.SaveMapping(dto);
-            return Ok(saved);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to save mapping for content type {ContentTypeAlias}", dto.ContentTypeAlias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst saving the schema mapping." });
-        }
+        var saved = _service.SaveMapping(dto);
+        return Ok(saved);
     }
 
     [HttpDelete("mappings/{contentTypeAlias}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [HandlesServerError("deleting the schema mapping")]
     public IActionResult DeleteMapping(string contentTypeAlias)
     {
-        try
-        {
-            _service.DeleteMapping(contentTypeAlias);
-            return NoContent();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to delete mapping for content type {ContentTypeAlias}", contentTypeAlias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst deleting the schema mapping." });
-        }
+        _service.DeleteMapping(contentTypeAlias);
+        return NoContent();
     }
 
     [HttpGet("mappings/drift")]
     [ProducesResponseType(typeof(MappingDriftReportDto), StatusCodes.Status200OK)]
+    [HandlesServerError("computing mapping drift")]
     public IActionResult GetMappingDrift()
     {
-        try
-        {
-            return Ok(_driftReporter.GetReport());
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to compute schema mapping drift");
-            return StatusCode(500, new { error = "An unexpected error occurred whilst computing mapping drift." });
-        }
+        return Ok(_driftReporter.GetReport());
     }
 
     [HttpPost("mappings/export")]
     [ProducesResponseType(typeof(MappingExportResultDto), StatusCodes.Status200OK)]
+    [HandlesServerError("exporting mappings to uSync")]
     public IActionResult ExportMappings([FromBody] MappingExportRequest? request = null)
     {
-        try
-        {
-            return Ok(_mappingExporter.Export(request?.ContentTypeAlias));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to export schema mappings to uSync");
-            return StatusCode(500, new { error = "An unexpected error occurred whilst exporting mappings to uSync." });
-        }
+        return Ok(_mappingExporter.Export(request?.ContentTypeAlias));
     }
 
     [HttpPost("mappings/{contentTypeAlias}/auto-map")]
     [ProducesResponseType(typeof(IEnumerable<PropertyMappingSuggestion>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [HandlesServerError("generating auto-map suggestions")]
     public async Task<IActionResult> AutoMap(string contentTypeAlias, [FromQuery] string schemaTypeName)
     {
-        try
-        {
-            if (string.IsNullOrWhiteSpace(schemaTypeName))
-                return BadRequest("schemaTypeName query parameter is required.");
+        if (string.IsNullOrWhiteSpace(schemaTypeName))
+            return BadRequest("schemaTypeName query parameter is required.");
 
-            // Awaits the seam: heuristic by default, AI when the SchemeWeaver.AI satellite overrides it.
-            var suggestions = await _service.AutoMapAsync(contentTypeAlias, schemaTypeName).ConfigureAwait(false);
-            return Ok(suggestions);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to auto-map {ContentTypeAlias} to {SchemaTypeName}", contentTypeAlias, schemaTypeName);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst generating auto-map suggestions." });
-        }
+        // Awaits the seam: heuristic by default, AI when the SchemeWeaver.AI satellite overrides it.
+        var suggestions = await _service.AutoMapAsync(contentTypeAlias, schemaTypeName).ConfigureAwait(false);
+        return Ok(suggestions);
     }
 
     [HttpPost("mappings/{contentTypeAlias}/preview")]
     [ProducesResponseType(typeof(JsonLdPreviewResponse), StatusCodes.Status200OK)]
+    [HandlesServerError("generating the JSON-LD preview")]
     public IActionResult Preview(string contentTypeAlias, [FromQuery] Guid? contentKey = null, [FromQuery] Guid? blockInstanceKey = null, [FromQuery] string? culture = null)
     {
-        try
+        // When a content key is provided, generate real JSON-LD from published content
+        if (contentKey.HasValue && contentKey.Value != Guid.Empty)
         {
-            // When a content key is provided, generate real JSON-LD from published content
-            if (contentKey.HasValue && contentKey.Value != Guid.Empty)
+            if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
             {
-                if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext))
-                {
-                    return StatusCode(StatusCodes.Status500InternalServerError, "Unable to access Umbraco context.");
-                }
-
-                var content = umbracoContext.Content?.GetById(contentKey.Value);
-                if (content == null) return NotFound("Content not found.");
-
-                // Block-instance preview: render the real JSON-LD a single nested block contributes
-                // to its page (via the page mapping's route for that block type).
-                if (blockInstanceKey is { } bik && bik != Guid.Empty)
-                {
-                    return Ok(_service.GenerateBlockInstancePreview(content, bik, culture));
-                }
-
-                var preview = _service.GeneratePreview(content, culture);
-                return Ok(preview);
+                return StatusCode(StatusCodes.Status500InternalServerError, "Unable to access Umbraco context.");
             }
 
-            // No content key — return mock preview based on mapping configuration
-            var mockPreview = _service.GenerateMockPreview(contentTypeAlias);
-            return Ok(mockPreview);
+            var content = umbracoContext.Content?.GetById(contentKey.Value);
+            if (content == null) return NotFound("Content not found.");
+
+            // Block-instance preview: render the real JSON-LD a single nested block contributes
+            // to its page (via the page mapping's route for that block type).
+            if (blockInstanceKey is { } bik && bik != Guid.Empty)
+            {
+                return Ok(_service.GenerateBlockInstancePreview(content, bik, culture));
+            }
+
+            var preview = _service.GeneratePreview(content, culture);
+            return Ok(preview);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to generate preview for content type {ContentTypeAlias}", contentTypeAlias);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst generating the JSON-LD preview." });
-        }
+
+        // No content key — return mock preview based on mapping configuration
+        var mockPreview = _service.GenerateMockPreview(contentTypeAlias);
+        return Ok(mockPreview);
     }
 
     #endregion
@@ -421,24 +329,17 @@ public class SchemeWeaverApiController : ControllerBase
     [HttpPost("generate-content-type")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [HandlesServerError("generating the content type")]
     public async Task<IActionResult> GenerateContentType([FromBody] ContentTypeGenerationRequest request, CancellationToken cancellationToken)
     {
-        try
-        {
-            if (string.IsNullOrWhiteSpace(request.SchemaTypeName))
-                return BadRequest("SchemaTypeName is required.");
+        if (string.IsNullOrWhiteSpace(request.SchemaTypeName))
+            return BadRequest("SchemaTypeName is required.");
 
-            if (string.IsNullOrWhiteSpace(request.DocumentTypeName))
-                return BadRequest("DocumentTypeName is required.");
+        if (string.IsNullOrWhiteSpace(request.DocumentTypeName))
+            return BadRequest("DocumentTypeName is required.");
 
-            var key = await _contentTypeGenerator.GenerateContentTypeAsync(request, cancellationToken).ConfigureAwait(false);
-            return Ok(new { Key = key });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to generate content type from schema {SchemaTypeName}", request.SchemaTypeName);
-            return StatusCode(500, new { error = "An unexpected error occurred whilst generating the content type." });
-        }
+        var key = await _contentTypeGenerator.GenerateContentTypeAsync(request, cancellationToken).ConfigureAwait(false);
+        return Ok(new { Key = key });
     }
 
     #endregion

--- a/src/Umbraco.Community.SchemeWeaver/Graph/GraphGenerator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Graph/GraphGenerator.cs
@@ -139,11 +139,8 @@ public sealed class GraphGenerator : IGraphGenerator
         };
 
         var nodes = new List<JsonObject>(needed.Count);
-        foreach (var piece in needed)
+        foreach (var piece in needed.Where(p => PieceMatchesScope(p, scope)))
         {
-            if (!PieceMatchesScope(piece, scope))
-                continue;
-
             try
             {
                 var thing = piece.Build(buildContext);

--- a/src/Umbraco.Community.SchemeWeaver/Graph/GraphGenerator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Graph/GraphGenerator.cs
@@ -260,10 +260,8 @@ public sealed class GraphGenerator : IGraphGenerator
     {
         collapsed = null!;
         if (obj.Count != 2) return false;
-        if (!obj.ContainsKey("@id")) return false;
+        if (!obj.TryGetPropertyValue("@id", out var idValue)) return false;
         if (!obj.ContainsKey("@type")) return false;
-
-        var idValue = obj["@id"];
         if (idValue is null) return false;
 
         collapsed = new JsonObject { ["@id"] = idValue.DeepClone() };

--- a/src/Umbraco.Community.SchemeWeaver/Graph/Pieces/MainEntityPiece.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Graph/Pieces/MainEntityPiece.cs
@@ -108,16 +108,14 @@ public sealed class MainEntityPiece : IGraphPiece
         // auto-wire them to the Organization piece. Scoped to these two
         // subtypes to avoid surprising users who map, say, an Article inside
         // a WebPage wrapper.
-        if (thing is AboutPage or ContactPage)
+        if (thing is AboutPage or ContactPage
+            && ctx.IdFor("organization") is { } orgId
+            && Uri.TryCreate(orgId, UriKind.Absolute, out var orgUri))
         {
-            if (ctx.IdFor("organization") is { } orgId
-                && Uri.TryCreate(orgId, UriKind.Absolute, out var orgUri))
-            {
-                if (page.About.Count == 0)
-                    page.About = new Organization { Id = orgUri };
-                if (page.MainEntity.Count == 0)
-                    page.MainEntity = new Organization { Id = orgUri };
-            }
+            if (page.About.Count == 0)
+                page.About = new Organization { Id = orgUri };
+            if (page.MainEntity.Count == 0)
+                page.MainEntity = new Organization { Id = orgUri };
         }
     }
 }

--- a/src/Umbraco.Community.SchemeWeaver/Graph/SiteSettingsResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Graph/SiteSettingsResolver.cs
@@ -93,13 +93,7 @@ public sealed class SiteSettingsResolver : ISiteSettingsResolver
     private static IPublishedContent? FirstPublished(
         IEnumerable<Guid> keys,
         Umbraco.Cms.Core.PublishedCache.IPublishedContentCache cache)
-    {
-        foreach (var key in keys)
-        {
-            var content = cache.GetById(key);
-            if (content is not null)
-                return content;
-        }
-        return null;
-    }
+        => keys
+            .Select(key => cache.GetById(key))
+            .FirstOrDefault(content => content is not null);
 }

--- a/src/Umbraco.Community.SchemeWeaver/Notifications/JsonLdCacheInvalidator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Notifications/JsonLdCacheInvalidator.cs
@@ -33,9 +33,8 @@ internal static class JsonLdCacheInvalidator
         var ripple = alwaysRippleToDescendants;
         var any = false;
 
-        foreach (var content in entities)
+        foreach (var content in entities.Where(c => c is not null))
         {
-            if (content is null) continue;
             provider.Invalidate(content.Key);
             any = true;
 

--- a/src/Umbraco.Community.SchemeWeaver/Services/Advisory/MappingAdvisor.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Advisory/MappingAdvisor.cs
@@ -95,10 +95,8 @@ public sealed class MappingAdvisor : IMappingAdvisor
         {
             if (config.Routes is { Count: > 0 } routes)
             {
-                foreach (var route in routes)
+                foreach (var route in routes.Where(r => !string.IsNullOrWhiteSpace(r.NestedSchemaType)))
                 {
-                    if (string.IsNullOrWhiteSpace(route.NestedSchemaType))
-                        continue;
                     AddMissingRequiredForRoute(entry, route.NestedSchemaType!, route.BlockAlias,
                         route.PropertyMappings?.Select(m => m.SchemaProperty), advices);
                 }
@@ -153,20 +151,14 @@ public sealed class MappingAdvisor : IMappingAdvisor
         var covered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (mappedProperties is not null)
         {
-            foreach (var p in mappedProperties)
-            {
-                if (!string.IsNullOrWhiteSpace(p))
-                    covered.Add(p!);
-            }
+            foreach (var p in mappedProperties.Where(p => !string.IsNullOrWhiteSpace(p)))
+                covered.Add(p!);
         }
 
         var prefix = string.IsNullOrWhiteSpace(blockAlias) ? string.Empty : $"Block '{blockAlias}': ";
 
-        foreach (var requiredProp in required)
+        foreach (var requiredProp in required.Where(p => !covered.Contains(p)))
         {
-            if (covered.Contains(requiredProp))
-                continue;
-
             advices.Add(new MappingAdvice(
                 MappingAdviceKind.MissingRequiredNestedProperty, entry.SchemaTypeName, entry.SchemaPropertyName,
                 $"{prefix}{nestedType} does not map '{requiredProp}', which Google's rich result requires — " +

--- a/src/Umbraco.Community.SchemeWeaver/Services/BlockSchemaSuggester.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/BlockSchemaSuggester.cs
@@ -202,22 +202,18 @@ public class BlockSchemaSuggester : IBlockSchemaSuggester
         var covered = new HashSet<string>(result.Select(r => r.SchemaProperty), StringComparer.OrdinalIgnoreCase);
 
         var suggestions = _autoMapper.SuggestMappings(element.Alias, entry.SchemaType);
-        foreach (var s in suggestions)
+        // Concrete content-property rows only; the keyword template wins for
+        // schema properties it already mapped.
+        foreach (var s in suggestions.Where(s =>
+                     !string.IsNullOrEmpty(s.SuggestedContentTypePropertyAlias)
+                     && string.Equals(s.SuggestedSourceType, "property", StringComparison.OrdinalIgnoreCase)
+                     && !s.SuggestedContentTypePropertyAlias.StartsWith(SchemeWeaverConstants.BuiltInProperties.Prefix, StringComparison.Ordinal)
+                     && !covered.Contains(s.SchemaPropertyName)))
         {
-            if (string.IsNullOrEmpty(s.SuggestedContentTypePropertyAlias))
-                continue;
-            if (!string.Equals(s.SuggestedSourceType, "property", StringComparison.OrdinalIgnoreCase))
-                continue;
-            if (s.SuggestedContentTypePropertyAlias.StartsWith(SchemeWeaverConstants.BuiltInProperties.Prefix, StringComparison.Ordinal))
-                continue;
-            // The keyword template wins for properties it already mapped.
-            if (covered.Contains(s.SchemaPropertyName))
-                continue;
-
             result.Add(new BlockRoutePropertyMappingSuggestion
             {
                 SchemaProperty = s.SchemaPropertyName,
-                ContentProperty = s.SuggestedContentTypePropertyAlias,
+                ContentProperty = s.SuggestedContentTypePropertyAlias!, // non-null: guarded in the Where above
                 // §3b: pre-fill stripHtml when a rich-text source feeds a plain-text nested property,
                 // so the suggested route emits clean text by default (revertible by the author).
                 TransformType = ShouldStripHtml(s) ? "stripHtml" : null,
@@ -296,11 +292,9 @@ public class BlockSchemaSuggester : IBlockSchemaSuggester
 
         foreach (var propInfo in element.PropertyInfos.Where(p => p.NestedBlockElementTypes.Count > 0))
         {
-            foreach (var suggestion in Suggest(propInfo.NestedBlockElementTypes, depth + 1))
+            foreach (var suggestion in Suggest(propInfo.NestedBlockElementTypes, depth + 1)
+                         .Where(s => s.Routes.Count > 0))
             {
-                if (suggestion.Routes.Count == 0)
-                    continue;
-
                 result.Add(new BlockRoutePropertyMappingSuggestion
                 {
                     SchemaProperty = suggestion.SchemaProperty,

--- a/src/Umbraco.Community.SchemeWeaver/Services/JsonLdBlocksProvider.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/JsonLdBlocksProvider.cs
@@ -48,8 +48,29 @@ public sealed class JsonLdBlocksProvider : IJsonLdBlocksProvider, IDisposable
         return _cache.GetOrCreate(cacheKey, entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = _options.CacheDuration;
+
+            // Same dispose race as the global token below, on the hotter path: Invalidate(key)
+            // (fired on every publish) removes-and-disposes this CTS between our GetOrAdd and
+            // .Token. The disposed source is already out of the dictionary, so one retry gets a
+            // fresh CTS; a second loss in a row falls back to the absolute expiration.
             var perContent = _perContentTokens.GetOrAdd(content.Key, _ => new CancellationTokenSource());
-            entry.AddExpirationToken(new CancellationChangeToken(perContent.Token));
+            try
+            {
+                entry.AddExpirationToken(new CancellationChangeToken(perContent.Token));
+            }
+            catch (ObjectDisposedException)
+            {
+                _perContentTokens.TryRemove(new KeyValuePair<Guid, CancellationTokenSource>(content.Key, perContent));
+                var fresh = _perContentTokens.GetOrAdd(content.Key, _ => new CancellationTokenSource());
+                try
+                {
+                    entry.AddExpirationToken(new CancellationChangeToken(fresh.Token));
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Lost the race twice — the absolute expiration still bounds this entry.
+                }
+            }
 
             // Rare race: InvalidateAll() disposes the CTS between our field read and .Token —
             // retry once with the fresh token, else skip it (the per-content token and the

--- a/src/Umbraco.Community.SchemeWeaver/Services/JsonLdBlocksProvider.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/JsonLdBlocksProvider.cs
@@ -50,7 +50,27 @@ public sealed class JsonLdBlocksProvider : IJsonLdBlocksProvider, IDisposable
             entry.AbsoluteExpirationRelativeToNow = _options.CacheDuration;
             var perContent = _perContentTokens.GetOrAdd(content.Key, _ => new CancellationTokenSource());
             entry.AddExpirationToken(new CancellationChangeToken(perContent.Token));
-            entry.AddExpirationToken(new CancellationChangeToken(_globalToken.Token));
+
+            // Rare race: InvalidateAll() disposes the CTS between our field read and .Token —
+            // retry once with the fresh token, else skip it (the per-content token and the
+            // absolute expiration still bound this entry's lifetime).
+            var global = _globalToken;
+            try
+            {
+                entry.AddExpirationToken(new CancellationChangeToken(global.Token));
+            }
+            catch (ObjectDisposedException)
+            {
+                try
+                {
+                    entry.AddExpirationToken(new CancellationChangeToken(_globalToken.Token));
+                }
+                catch (ObjectDisposedException)
+                {
+                    // A second InvalidateAll raced us too — give up on the global token for this pass.
+                }
+            }
+
             return Generate(content, culture, scope);
         }) ?? Array.Empty<string>();
     }

--- a/src/Umbraco.Community.SchemeWeaver/Services/JsonLdGenerator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/JsonLdGenerator.cs
@@ -645,11 +645,8 @@ public partial class JsonLdGenerator : IJsonLdGenerator
         if (config?.ComplexTypeMappings is null or { Count: 0 })
             return null; // No sub-mappings configured — skip rather than emit empty object
 
-        foreach (var subMapping in config.ComplexTypeMappings)
+        foreach (var subMapping in config.ComplexTypeMappings.Where(m => !string.IsNullOrEmpty(m.SchemaProperty)))
         {
-            if (string.IsNullOrEmpty(subMapping.SchemaProperty))
-                continue;
-
             object? value = subMapping.SourceType switch
             {
                 "static" => subMapping.StaticValue,

--- a/src/Umbraco.Community.SchemeWeaver/Services/Mapping/StructuralEnricher.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Mapping/StructuralEnricher.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Umbraco.Community.SchemeWeaver.Models.Api;
 using Umbraco.Community.SchemeWeaver.Services.Advisory;
 
@@ -35,6 +36,7 @@ public sealed class StructuralEnricher
     private readonly ISchemaTypeRegistry _registry;
     private readonly Func<string, IReadOnlyList<string>, string?> _matchAlias;
     private readonly int _showThreshold;
+    private readonly ILogger? _logger;
 
     private static readonly HashSet<string> BlockEditorAliases =
         SchemeWeaverConstants.PropertyEditors.BlockEditorAliases;
@@ -42,14 +44,17 @@ public sealed class StructuralEnricher
     /// <param name="registry">Schema registry, for nested-type property lookup and range checks.</param>
     /// <param name="matchAlias">Best-effort exact/synonym/partial match of a schema property name against a set of candidate aliases (mirrors the flat loop), or null when nothing matches.</param>
     /// <param name="showThreshold">The show-confidence threshold, used as a floor for structurally-confirmed rows.</param>
+    /// <param name="logger">Optional logger for swallowed per-suggestion enrichment failures (this class is hand-constructed, so the caller's own logger is fine).</param>
     public StructuralEnricher(
         ISchemaTypeRegistry registry,
         Func<string, IReadOnlyList<string>, string?> matchAlias,
-        int showThreshold)
+        int showThreshold,
+        ILogger? logger = null)
     {
         _registry = registry;
         _matchAlias = matchAlias;
         _showThreshold = showThreshold;
+        _logger = logger;
     }
 
     /// <summary>
@@ -70,10 +75,13 @@ public sealed class StructuralEnricher
             {
                 EnrichOne(suggestion, contentPropertyAliases, blockElementsFor);
             }
-            catch
+            catch (Exception ex)
             {
                 // Structural enrichment is strictly additive — never let a malformed block
                 // configuration or unexpected registry shape break the flat suggestion.
+                _logger?.LogDebug(ex,
+                    "Structural enrichment failed for schema property {SchemaProperty} — keeping the flat suggestion",
+                    suggestion.SchemaPropertyName);
             }
         }
 

--- a/src/Umbraco.Community.SchemeWeaver/Services/Mapping/StructuralEnricher.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Mapping/StructuralEnricher.cs
@@ -311,24 +311,13 @@ public sealed class StructuralEnricher
         if (nestedClr is null)
             return true;
 
-        foreach (var accepted in acceptedTypes)
-        {
-            if (SchemaPrimitiveTypes.IsPrimitive(accepted))
-                continue;
-            if (string.Equals(accepted, nestedType, StringComparison.OrdinalIgnoreCase))
-                return true;
-
-            var acceptedClr = _registry.GetClrType(accepted);
-            if (acceptedClr is not null && acceptedClr.IsAssignableFrom(nestedClr))
-                return true;
-
-            if (nestedClr.GetInterfaces().Any(i =>
+        return acceptedTypes.Any(accepted =>
+            !SchemaPrimitiveTypes.IsPrimitive(accepted)
+            && (string.Equals(accepted, nestedType, StringComparison.OrdinalIgnoreCase)
+                || (_registry.GetClrType(accepted) is { } acceptedClr && acceptedClr.IsAssignableFrom(nestedClr))
+                || nestedClr.GetInterfaces().Any(i =>
                     string.Equals(i.Name, "I" + accepted, StringComparison.Ordinal)
-                    || string.Equals(i.Name, accepted, StringComparison.Ordinal)))
-                return true;
-        }
-
-        return false;
+                    || string.Equals(i.Name, accepted, StringComparison.Ordinal))));
     }
 
     private static bool IsRichSourceType(string? sourceType) =>

--- a/src/Umbraco.Community.SchemeWeaver/Services/Media/MediaImageObjectFactory.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Media/MediaImageObjectFactory.cs
@@ -53,13 +53,7 @@ public static class MediaImageObjectFactory
     }
 
     private static string? ResolveCaption(IPublishedContent media)
-    {
-        foreach (var alias in _captionAliases)
-        {
-            var value = media.Value<string?>(alias);
-            if (!string.IsNullOrWhiteSpace(value))
-                return value;
-        }
-        return null;
-    }
+        => _captionAliases
+            .Select(alias => media.Value<string?>(alias))
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 }

--- a/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
@@ -40,7 +40,12 @@ public class BlockContentResolver : IPropertyValueResolver
             return null;
 
         if (context.RecursionDepth >= context.MaxRecursionDepth)
+        {
+            _logger.LogDebug(
+                "Skipping block content resolution for property {PropertyAlias}: recursion depth {Depth} reached max {MaxDepth}",
+                context.PropertyAlias, context.RecursionDepth, context.MaxRecursionDepth);
             return null;
+        }
 
         var resolverConfig = ParseResolverConfig(context.Mapping.ResolverConfig);
 

--- a/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
@@ -324,17 +324,9 @@ public class BlockContentResolver : IPropertyValueResolver
     /// Schema.NET's own serializer, so "has a resolved property" ⇔ "will emit a property".
     /// </summary>
     private static bool HasResolvedProperty(Thing thing)
-    {
-        foreach (var p in thing.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (p.GetIndexParameters().Length > 0)
-                continue;
-            if (p.GetValue(thing) is IValues { Count: > 0 })
-                return true;
-        }
-
-        return false;
-    }
+        => thing.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Any(p => p.GetIndexParameters().Length == 0
+                      && p.GetValue(thing) is IValues { Count: > 0 });
 
     /// <summary>
     /// True when the named schema property (case-insensitive) is set to a non-empty
@@ -342,16 +334,12 @@ public class BlockContentResolver : IPropertyValueResolver
     /// </summary>
     private static bool HasNamedProperty(Thing thing, string schemaPropertyName)
     {
-        foreach (var p in thing.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (p.GetIndexParameters().Length > 0)
-                continue;
-            if (!string.Equals(p.Name, schemaPropertyName, StringComparison.OrdinalIgnoreCase))
-                continue;
-            return p.GetValue(thing) is IValues { Count: > 0 };
-        }
+        // First-match-then-inspect: only the FIRST property with the matching name decides.
+        var match = thing.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(p => p.GetIndexParameters().Length == 0
+                                 && string.Equals(p.Name, schemaPropertyName, StringComparison.OrdinalIgnoreCase));
 
-        return false;
+        return match?.GetValue(thing) is IValues { Count: > 0 };
     }
 
     /// <summary>
@@ -378,12 +366,9 @@ public class BlockContentResolver : IPropertyValueResolver
             return;
 
         var wroteAtLeastOne = false;
-        foreach (var mapping in group)
+        foreach (var mapping in group.Where(m => !string.IsNullOrEmpty(m.ContentProperty)))
         {
-            if (string.IsNullOrEmpty(mapping.ContentProperty))
-                continue;
-
-            var rawValue = ResolveBlockElementProperty(blockContent, mapping.ContentProperty, context);
+            var rawValue = ResolveBlockElementProperty(blockContent, mapping.ContentProperty!, context);
             if (rawValue is null)
                 continue;
 
@@ -624,14 +609,12 @@ public class BlockContentResolver : IPropertyValueResolver
     {
         var schemaProperties = context.SchemaTypeRegistry.GetProperties(schemaTypeName).ToList();
 
-        foreach (var schemaProp in schemaProperties)
+        // Skip nested Block List/Grid properties — auto-map has no schema route for their
+        // child blocks, and ResolveElementPropertyValue would otherwise stamp the block
+        // model's ToString() onto the schema property. Nested blocks require explicit routes.
+        foreach (var schemaProp in schemaProperties.Where(sp =>
+                     !IsBlockEditor(blockContent.GetProperty(sp.Name)?.PropertyType?.EditorAlias)))
         {
-            // Skip nested Block List/Grid properties — auto-map has no schema route for their
-            // child blocks, and ResolveElementPropertyValue would otherwise stamp the block
-            // model's ToString() onto the schema property. Nested blocks require explicit routes.
-            if (IsBlockEditor(blockContent.GetProperty(schemaProp.Name)?.PropertyType?.EditorAlias))
-                continue;
-
             // Try exact name match (case-insensitive) between block property and schema property
             var rawValue = SchemaPropertySetter.ResolveElementPropertyValue(
                 blockContent, schemaProp.Name, context.HttpContextAccessor);

--- a/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/MediaPickerResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/MediaPickerResolver.cs
@@ -51,11 +51,8 @@ public class MediaPickerResolver : IPropertyValueResolver
         };
 
         var images = new List<ImageObject>();
-        foreach (var node in mediaNodes)
+        foreach (var node in mediaNodes.OfType<IPublishedContent>())
         {
-            if (node is null)
-                continue;
-
             var image = MediaImageObjectFactory.Create(node, _urlProvider);
             if (image is not null)
                 images.Add(image);

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaAutoMapper.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaAutoMapper.cs
@@ -910,14 +910,10 @@ public class SchemaAutoMapper : ISchemaAutoMapper
         if (elementKeys.Count == 0)
             return [];
 
-        var result = new List<BlockElementTypeInfo>();
-        foreach (var key in elementKeys)
-        {
-            var elementType = _contentTypeService.Get(key);
-            if (elementType is null)
-                continue;
-
-            result.Add(new BlockElementTypeInfo
+        return elementKeys
+            .Select(key => _contentTypeService.Get(key))
+            .OfType<IContentType>()
+            .Select(elementType => new BlockElementTypeInfo
             {
                 Alias = elementType.Alias,
                 Name = elementType.Name ?? elementType.Alias,
@@ -928,10 +924,8 @@ public class SchemaAutoMapper : ISchemaAutoMapper
                     Name = p.Name ?? p.Alias,
                     EditorAlias = p.PropertyEditorAlias,
                 }).ToList(),
-            });
-        }
-
-        return result;
+            })
+            .ToList();
     }
 
     /// <summary>

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaAutoMapper.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaAutoMapper.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -17,6 +18,7 @@ public class SchemaAutoMapper : ISchemaAutoMapper
     private readonly IContentTypeService _contentTypeService;
     private readonly ISchemaTypeRegistry _schemaTypeRegistry;
     private readonly IDataTypeService? _dataTypeService;
+    private readonly ILogger<SchemaAutoMapper>? _logger;
     private readonly int _autoApplyThreshold;
     private readonly int _showThreshold;
 
@@ -355,11 +357,13 @@ public class SchemaAutoMapper : ISchemaAutoMapper
         IContentTypeService contentTypeService,
         ISchemaTypeRegistry schemaTypeRegistry,
         IOptions<SchemaAutoMapperOptions>? options = null,
-        IDataTypeService? dataTypeService = null)
+        IDataTypeService? dataTypeService = null,
+        ILogger<SchemaAutoMapper>? logger = null)
     {
         _contentTypeService = contentTypeService;
         _schemaTypeRegistry = schemaTypeRegistry;
         _dataTypeService = dataTypeService;
+        _logger = logger;
 
         var opts = options?.Value ?? new SchemaAutoMapperOptions();
         _autoApplyThreshold = opts.AutoApplyConfidenceThreshold;
@@ -591,7 +595,7 @@ public class SchemaAutoMapper : ISchemaAutoMapper
             return elements;
         }
 
-        var enricher = new StructuralEnricher(_schemaTypeRegistry, MatchPropertyAlias, _showThreshold);
+        var enricher = new StructuralEnricher(_schemaTypeRegistry, MatchPropertyAlias, _showThreshold, _logger);
         enricher.Enrich(suggestions, contentPropertyAliases, BlockElementsFor);
 
         // Threshold pass (authoritative over the per-branch IsAutoMapped values above):
@@ -891,8 +895,11 @@ public class SchemaAutoMapper : ISchemaAutoMapper
         {
             dataType = _dataTypeService.GetAsync(property.DataTypeKey).GetAwaiter().GetResult();
         }
-        catch
+        catch (Exception ex)
         {
+            _logger?.LogDebug(ex,
+                "Failed to load data type {DataTypeKey} for block property {PropertyAlias} — skipping block introspection",
+                property.DataTypeKey, propertyAlias);
             return [];
         }
 

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
@@ -610,7 +610,7 @@ public static class SchemaPropertySetter
     /// Returns false when none of those CLR types are among the Values type arguments or the
     /// string parses to none of them.
     /// </summary>
-    internal static bool TryParseDateOrNumber(Type[] valuesArgs, string value, out object? parsed)
+    internal static bool TryParseDateOrNumber(IReadOnlyList<Type> valuesArgs, string value, out object? parsed)
     {
         parsed = null;
 
@@ -620,35 +620,33 @@ public static class SchemaPropertySetter
         var acceptsDateTime = Accepts<DateTime>();
         var acceptsInt = Accepts<int>();
 
-        if (acceptsDateTimeOffset || acceptsDateTime)
+        // RoundtripKind keeps the parsed Kind faithful to the input: Utc/Local when the
+        // string carried a zone, Unspecified when it didn't.
+        if ((acceptsDateTimeOffset || acceptsDateTime)
+            && DateTime.TryParse(value, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var dt))
         {
-            // RoundtripKind keeps the parsed Kind faithful to the input: Utc/Local when the
-            // string carried a zone, Unspecified when it didn't.
-            if (DateTime.TryParse(value, CultureInfo.InvariantCulture,
-                    DateTimeStyles.RoundtripKind, out var dt))
+            var hadOffset = dt.Kind != DateTimeKind.Unspecified;
+            if (hadOffset && acceptsDateTimeOffset
+                && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind, out var dto))
             {
-                var hadOffset = dt.Kind != DateTimeKind.Unspecified;
-                if (hadOffset && acceptsDateTimeOffset
-                    && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
-                        DateTimeStyles.RoundtripKind, out var dto))
-                {
-                    parsed = dto;
-                    return true;
-                }
+                parsed = dto;
+                return true;
+            }
 
-                if (acceptsDateTime)
-                {
-                    parsed = dt;
-                    return true;
-                }
+            if (acceptsDateTime)
+            {
+                parsed = dt;
+                return true;
+            }
 
-                if (acceptsDateTimeOffset
-                    && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
-                        DateTimeStyles.RoundtripKind, out var dtoFallback))
-                {
-                    parsed = dtoFallback;
-                    return true;
-                }
+            if (acceptsDateTimeOffset
+                && DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind, out var dtoFallback))
+            {
+                parsed = dtoFallback;
+                return true;
             }
         }
 

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
@@ -295,23 +295,17 @@ public static class SchemaPropertySetter
 
         if (preferred is not null)
         {
-            foreach (var iface in candidateInterfaces)
-            {
-                var concrete = InterfaceToConcrete(iface);
-                if (concrete is not null && concrete.Name == preferred)
-                    return concrete;
-            }
+            var preferredConcrete = candidateInterfaces
+                .Select(InterfaceToConcrete)
+                .FirstOrDefault(concrete => concrete is not null && concrete.Name == preferred);
+            if (preferredConcrete is not null)
+                return preferredConcrete;
         }
 
         // Fallback: first candidate that resolves to a concrete type.
-        foreach (var iface in candidateInterfaces)
-        {
-            var concrete = InterfaceToConcrete(iface);
-            if (concrete is not null)
-                return concrete;
-        }
-
-        return null;
+        return candidateInterfaces
+            .Select(InterfaceToConcrete)
+            .FirstOrDefault(concrete => concrete is not null);
     }
 
     /// <summary>
@@ -348,11 +342,8 @@ public static class SchemaPropertySetter
                 // Build a typed List<IFoo> and use the op_Implicit(List<IFoo>) operator
                 var typedListType = typeof(List<>).MakeGenericType(matchingInterfaceType);
                 var typedItemList = (IList)Activator.CreateInstance(typedListType)!;
-                foreach (var thing in thingList)
-                {
-                    if (matchingInterfaceType.IsAssignableFrom(thing.GetType()))
-                        typedItemList.Add(thing);
-                }
+                foreach (var thing in thingList.Where(t => matchingInterfaceType.IsAssignableFrom(t.GetType())))
+                    typedItemList.Add(thing);
 
                 if (typedItemList.Count > 0)
                 {
@@ -386,11 +377,11 @@ public static class SchemaPropertySetter
         var listType = typeof(List<>).MakeGenericType(innerType);
         var typedList = (IList)Activator.CreateInstance(listType)!;
 
-        foreach (var thing in thingList)
+        foreach (var converted in thingList
+                     .Select(thing => TryConvertViaImplicit(innerType, thing))
+                     .Where(converted => converted is not null))
         {
-            var converted = TryConvertViaImplicit(innerType, thing);
-            if (converted is not null)
-                typedList.Add(converted);
+            typedList.Add(converted);
         }
 
         if (typedList.Count == 0)

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemeWeaverService.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemeWeaverService.cs
@@ -152,12 +152,8 @@ public class SchemeWeaverService : ISchemeWeaverService
                 pm.NestedSchemaTypeName,
                 pm.ResolverConfig);
 
-            foreach (var advice in _advisor.AdviseEntry(entry))
-            {
-                if (flaggedPaths.Contains(advice.Path))
-                    continue;
+            foreach (var advice in _advisor.AdviseEntry(entry).Where(a => !flaggedPaths.Contains(a.Path)))
                 warnings.Add(new ValidationIssueDto("suggestion", advice.SchemaType, advice.Path, advice.Message));
-            }
         }
 
         return warnings;

--- a/src/Umbraco.Community.SchemeWeaver/Services/Validation/SchemaRangeValidator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Validation/SchemaRangeValidator.cs
@@ -99,12 +99,9 @@ public class SchemaRangeValidator : ISchemaRangeValidator
         if (config?.Routes is not { Count: > 0 } routes)
             return;
 
-        foreach (var route in routes)
+        foreach (var route in routes.Where(r => !string.IsNullOrWhiteSpace(r.NestedSchemaType)))
         {
-            if (string.IsNullOrWhiteSpace(route.NestedSchemaType))
-                continue;
-
-            var chosenClr = _registry.GetClrType(route.NestedSchemaType);
+            var chosenClr = _registry.GetClrType(route.NestedSchemaType!);
             if (chosenClr is null)
                 continue;
 

--- a/src/Umbraco.Community.SchemeWeaver/wwwroot/umbraco-package.json
+++ b/src/Umbraco.Community.SchemeWeaver/wwwroot/umbraco-package.json
@@ -6,7 +6,7 @@
     {
       "type": "bundle",
       "alias": "Umbraco.Community.SchemeWeaver.WebComponents",
-      "js": "/App_Plugins/SchemeWeaver/dist/index.js?v=0d2cfdb9"
+      "js": "/App_Plugins/SchemeWeaver/dist/index.js?v=8386178e"
     }
   ]
 }

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Integration/HeuristicRichCoverageTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Integration/HeuristicRichCoverageTests.cs
@@ -90,7 +90,7 @@ public class HeuristicRichCoverageTests : IClassFixture<HeuristicRichCoverageFac
 
         foreach (var alias in RichContentTypes)
         {
-            var gold = ParseGold(Path.Combine(goldDir, GoldFileName(alias)));
+            var gold = ParseGold(Path.Join(goldDir, GoldFileName(alias)));
             var suggestions = (await autoMapper.SuggestMappingsAsync(alias, gold.SchemaType)).ToList();
 
             var score = Score(gold, suggestions);
@@ -256,7 +256,7 @@ public class HeuristicRichCoverageTests : IClassFixture<HeuristicRichCoverageFac
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null)
         {
-            var candidate = Path.Combine(
+            var candidate = Path.Join(
                 dir.FullName,
                 "src", "Umbraco.Community.SchemeWeaver.TestHost", "uSync", "v18", "SchemeWeaverMappings");
             if (Directory.Exists(candidate))

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Integration/RichResultsAudit.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Integration/RichResultsAudit.cs
@@ -251,10 +251,10 @@ public class RichResultsAudit : IClassFixture<RichResultsAuditFactory>
     private static string WriteReport(IReadOnlyList<AuditRow> rows)
     {
         var repoRoot = LocateRepoRoot();
-        var auditDir = Path.Combine(repoRoot, "docs", "audit");
+        var auditDir = Path.Join(repoRoot, "docs", "audit");
         Directory.CreateDirectory(auditDir);
 
-        var reportPath = Path.Combine(auditDir, $"rich-results-audit-{DateTime.UtcNow:yyyy-MM-dd}.md");
+        var reportPath = Path.Join(auditDir, $"rich-results-audit-{DateTime.UtcNow:yyyy-MM-dd}.md");
         var sb = new StringBuilder();
 
         var total = rows.Count;
@@ -330,7 +330,7 @@ public class RichResultsAudit : IClassFixture<RichResultsAuditFactory>
     private static string LocateRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Umbraco.Community.SchemeWeaver.slnx")))
+        while (dir is not null && !File.Exists(Path.Join(dir.FullName, "Umbraco.Community.SchemeWeaver.slnx")))
             dir = dir.Parent;
         return dir?.FullName ?? AppContext.BaseDirectory;
     }

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Controllers/HandlesServerErrorAttributeTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Controllers/HandlesServerErrorAttributeTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Umbraco.Community.SchemeWeaver.Controllers;
+using Xunit;
+
+namespace Umbraco.Community.SchemeWeaver.Tests.Unit.Controllers;
+
+/// <summary>
+/// Pins the frozen wire contract of <see cref="HandlesServerErrorAttribute"/>: HTTP 500 with a
+/// body that serialises to exactly <c>{"error":"An unexpected error occurred whilst …."}</c>
+/// (the frontend data source parses this shape — it must never become ProblemDetails), the
+/// exception marked handled, and the original exception logged at Error level.
+/// </summary>
+public class HandlesServerErrorAttributeTests
+{
+    private readonly ILogger<SchemeWeaverApiController> _logger =
+        Substitute.For<ILogger<SchemeWeaverApiController>>();
+
+    private ExceptionContext CreateExceptionContext(Exception exception)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton(_logger)
+            .BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var routeData = new RouteData();
+        routeData.Values["contentTypeAlias"] = "article";
+
+        var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
+
+        return new ExceptionContext(actionContext, [])
+        {
+            Exception = exception,
+        };
+    }
+
+    [Fact]
+    public void OnException_Returns500WithFrozenErrorBody()
+    {
+        var sut = new HandlesServerErrorAttribute("testing");
+        var context = CreateExceptionContext(new InvalidOperationException("boom"));
+
+        sut.OnException(context);
+
+        var result = context.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+
+        // The exact body shape is the wire contract the frontend parses — frozen.
+        JsonSerializer.Serialize(result.Value)
+            .Should().Be("""{"error":"An unexpected error occurred whilst testing."}""");
+    }
+
+    [Fact]
+    public void OnException_MarksExceptionHandled()
+    {
+        var sut = new HandlesServerErrorAttribute("testing");
+        var context = CreateExceptionContext(new InvalidOperationException("boom"));
+
+        sut.OnException(context);
+
+        context.ExceptionHandled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OnException_LogsTheOriginalExceptionAtErrorLevel()
+    {
+        var exception = new InvalidOperationException("boom");
+        var sut = new HandlesServerErrorAttribute("testing");
+        var context = CreateExceptionContext(exception);
+
+        sut.OnException(context);
+
+        // ILogger.Log<TState> is generic, so inspect the received call rather than
+        // matching the TState argument type directly.
+        var logCall = _logger.ReceivedCalls()
+            .Should().ContainSingle(c => c.GetMethodInfo().Name == nameof(ILogger.Log)).Subject;
+        var args = logCall.GetArguments();
+        args[0].Should().Be(LogLevel.Error);
+        args[3].Should().BeSameAs(exception);
+    }
+}

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/JsonLdCacheInvalidationTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/JsonLdCacheInvalidationTests.cs
@@ -48,7 +48,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnPublish(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnPublish>.Instance);
 
-        handler.Handle(new ContentPublishedNotification(target, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentPublishedNotification(target, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.DidNotReceive().InvalidateAll();
@@ -63,7 +64,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnPublish(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnPublish>.Instance);
 
-        handler.Handle(new ContentPublishedNotification(target, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentPublishedNotification(target, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.Received(1).InvalidateAll();
@@ -82,7 +84,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnPublish(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnPublish>.Instance);
 
-        handler.Handle(new ContentPublishedNotification(target, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentPublishedNotification(target, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.Received(1).InvalidateAll();
@@ -97,7 +100,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnUnpublish(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnUnpublish>.Instance);
 
-        handler.Handle(new ContentUnpublishedNotification(target, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentUnpublishedNotification(target, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.Received(1).InvalidateAll();
@@ -110,7 +114,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnDelete(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnDelete>.Instance);
 
-        handler.Handle(new ContentDeletedNotification(target, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentDeletedNotification(target, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.DidNotReceive().InvalidateAll();
@@ -129,7 +134,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnMove(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnMove>.Instance);
 
-        handler.Handle(new ContentMovedNotification(moveInfo, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentMovedNotification(moveInfo, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.Received(1).InvalidateAll(); // moves change ancestry/breadcrumbs regardless
@@ -143,7 +149,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnMove(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnMove>.Instance);
 
-        handler.Handle(new ContentMovedToRecycleBinNotification(moveInfo, new EventMessages()));
+        using var messages = new EventMessages();
+        handler.Handle(new ContentMovedToRecycleBinNotification(moveInfo, messages));
 
         _provider.Received(1).Invalidate(target.Key);
         _provider.Received(1).InvalidateAll();
@@ -158,7 +165,8 @@ public class JsonLdCacheInvalidationTests
         var handler = new InvalidateJsonLdCacheOnPublish(_provider, _repo,
             NullLogger<InvalidateJsonLdCacheOnPublish>.Instance);
 
-        var act = () => handler.Handle(new ContentPublishedNotification(target, new EventMessages()));
+        using var messages = new EventMessages();
+        var act = () => handler.Handle(new ContentPublishedNotification(target, messages));
 
         act.Should().NotThrow();
         _provider.Received(1).Invalidate(target.Key);

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/MediaPickerResolverTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Resolvers/MediaPickerResolverTests.cs
@@ -27,15 +27,31 @@ public class MediaPickerResolverTests
     static MediaPickerResolverTests()
     {
         // media.Value<int?>("umbracoWidth") flows through FriendlyPublishedContentExtensions,
-        // which resolves IPublishedValueFallback from StaticServiceProvider. Ensure it is set
-        // so the friendly extension does not throw during unit tests. Only set it when the
-        // ambient provider cannot already satisfy the dependency (e.g. under integration hosts).
+        // whose Umbraco 17 type initializer eagerly resolves ~17 services from
+        // StaticServiceProvider (18 resolves lazily per call). A fixed seed list is a moving
+        // target across minors, so install a provider that hands out substitutes on demand —
+        // with a real NoopPublishedValueFallback so Value<T>() behaves. Only installed when no
+        // ambient (integration-host) provider can already satisfy the friendly extensions;
+        // xUnit class scheduling is nondeterministic, so these tests must be hermetic.
         if (StaticServiceProvider.Instance?.GetService<IPublishedValueFallback>() is null)
         {
-            var services = new ServiceCollection();
-            services.AddSingleton<IPublishedValueFallback, NoopPublishedValueFallback>();
-            StaticServiceProvider.Instance = services.BuildServiceProvider();
+            StaticServiceProvider.Instance = new SubstituteServiceProvider();
         }
+    }
+
+    /// <summary>
+    /// Resolves a fresh NSubstitute mock for any interface requested, so eager static service
+    /// resolution in Umbraco's friendly extensions can never poison a type initializer here.
+    /// </summary>
+    private sealed class SubstituteServiceProvider : IServiceProvider
+    {
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<Type, object?> _services = new();
+
+        public object? GetService(Type serviceType)
+            => _services.GetOrAdd(serviceType, static t =>
+                t == typeof(IPublishedValueFallback) ? new NoopPublishedValueFallback()
+                : t.IsInterface ? Substitute.For(new[] { t }, Array.Empty<object>())
+                : null);
     }
 
     public MediaPickerResolverTests()

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/SchemaMappingHandlerTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/SchemaMappingHandlerTests.cs
@@ -102,8 +102,8 @@ public class SchemaMappingHandlerTests
     {
         // Arrange: a content root with a uSync/v18 data folder so the path resolver
         // picks the current-convention version sub-folder.
-        var contentRoot = Path.Combine(Path.GetTempPath(), "sw-usync-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(contentRoot, "uSync", "v18"));
+        var contentRoot = Path.Join(Path.GetTempPath(), "sw-usync-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Join(contentRoot, "uSync", "v18"));
 
         try
         {
@@ -136,7 +136,7 @@ public class SchemaMappingHandlerTests
             fileWriter.Write(folder, mapping.ContentTypeAlias, serialised.Item!);
 
             // A flat {alias}.config file lands exactly where uSync's handler writes it.
-            var expectedFile = Path.Combine(contentRoot, "uSync", "v18", "SchemeWeaverMappings", "blogPost.config");
+            var expectedFile = Path.Join(contentRoot, "uSync", "v18", "SchemeWeaverMappings", "blogPost.config");
             File.Exists(expectedFile).Should().BeTrue();
 
             // Act 2 — import: read the file back and deserialise into the repository.

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/SchemaPropertySetterTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/SchemaPropertySetterTests.cs
@@ -11,6 +11,10 @@ public class SchemaPropertySetterTests
     public void SetPropertyValue_OneOrManyUri_SetsFromString()
     {
         // Thing.Url is OneOrMany<Uri> — previously this was silently dropped
+        var urlProperty = typeof(Event).GetProperty("Url");
+        urlProperty.Should().NotBeNull();
+        urlProperty!.PropertyType.Should().Be(typeof(OneOrMany<System.Uri>));
+
         var thing = new Event();
         SchemaPropertySetter.SetPropertyValue(thing, "Url", "https://example.com/event");
 

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/SchemaMappingBootImportTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/SchemaMappingBootImportTests.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Community.SchemeWeaver.Tests.Unit.USync;
 /// </summary>
 public class SchemaMappingBootImportTests : IDisposable
 {
-    private readonly string _contentRoot = Path.Combine(Path.GetTempPath(), "sw-boot-" + Guid.NewGuid().ToString("N"));
+    private readonly string _contentRoot = Path.Join(Path.GetTempPath(), "sw-boot-" + Guid.NewGuid().ToString("N"));
     private readonly ISchemaMappingRepository _repository = Substitute.For<ISchemaMappingRepository>();
     private readonly IHostEnvironment _hostEnvironment = Substitute.For<IHostEnvironment>();
     private readonly SyncSerializerCollection _serializers;

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingDriftReporterTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingDriftReporterTests.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Community.SchemeWeaver.Tests.Unit.USync;
 
 public class USyncMappingDriftReporterTests : IDisposable
 {
-    private readonly string _contentRoot = Path.Combine(Path.GetTempPath(), "sw-drift-" + Guid.NewGuid().ToString("N"));
+    private readonly string _contentRoot = Path.Join(Path.GetTempPath(), "sw-drift-" + Guid.NewGuid().ToString("N"));
     private readonly ISchemaMappingRepository _repository = Substitute.For<ISchemaMappingRepository>();
     private readonly IHostEnvironment _hostEnvironment = Substitute.For<IHostEnvironment>();
     private readonly SyncSerializerCollection _serializers;
@@ -95,7 +95,7 @@ public class USyncMappingDriftReporterTests : IDisposable
         _repository.GetPropertyMappings(Arg.Any<int>()).Returns([]);
         CreateExporter().Export("article");
 
-        var path = Path.Combine(_contentRoot, "uSync", "v18", "SchemeWeaverMappings", "article.config");
+        var path = Path.Join(_contentRoot, "uSync", "v18", "SchemeWeaverMappings", "article.config");
         var xml = File.ReadAllText(path).Replace(key.ToString(), key.ToString().ToUpperInvariant());
         File.WriteAllText(path, xml);
 

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingExporterTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingExporterTests.cs
@@ -86,6 +86,23 @@ public class USyncMappingExporterTests : IDisposable
     }
 
     [Fact]
+    public void Export_UnsafeAlias_ReportsRefusal_WritesNothing()
+    {
+        // The writer refuses aliases that aren't plain file names; the export result must say
+        // so rather than claim Written = true for a file that does not exist.
+        _repository.GetAll().Returns(new[] { Mapping(1, @"..\evil") });
+        _repository.GetPropertyMappings(Arg.Any<int>()).Returns([]);
+        var (serializers, scopeFactory) = BuildSerializer();
+        var exporter = new USyncMappingExporter(serializers, scopeFactory, _hostEnvironment,
+            new MappingFileWriter(), Substitute.For<ILogger<USyncMappingExporter>>());
+
+        var result = exporter.Export();
+
+        result.Items.Should().ContainSingle(i => i.Alias == @"..\evil" && !i.Written && i.Error != null);
+        File.Exists(Path.Join(_contentRoot, "uSync", "evil.config")).Should().BeFalse();
+    }
+
+    [Fact]
     public void Export_ReadOnlyRoot_ReportsFailure_DoesNotThrow()
     {
         _repository.GetAll().Returns(new[] { Mapping(1, "article") });

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingExporterTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingExporterTests.cs
@@ -85,12 +85,15 @@ public class USyncMappingExporterTests : IDisposable
         File.Exists(Path.Join(result.Folder!, "article.config")).Should().BeTrue();
     }
 
-    [Fact]
-    public void Export_UnsafeAlias_ReportsRefusal_WritesNothing()
+    [Theory]
+    [InlineData("../evil")]
+    [InlineData(@"..\evil")]
+    public void Export_UnsafeAlias_ReportsRefusal_WritesNothing(string unsafeAlias)
     {
-        // The writer refuses aliases that aren't plain file names; the export result must say
+        // The writer refuses aliases that aren't plain file names — with BOTH separators, on
+        // every OS (uSync folders travel between machines) — and the export result must say
         // so rather than claim Written = true for a file that does not exist.
-        _repository.GetAll().Returns(new[] { Mapping(1, @"..\evil") });
+        _repository.GetAll().Returns(new[] { Mapping(1, unsafeAlias) });
         _repository.GetPropertyMappings(Arg.Any<int>()).Returns([]);
         var (serializers, scopeFactory) = BuildSerializer();
         var exporter = new USyncMappingExporter(serializers, scopeFactory, _hostEnvironment,
@@ -98,7 +101,7 @@ public class USyncMappingExporterTests : IDisposable
 
         var result = exporter.Export();
 
-        result.Items.Should().ContainSingle(i => i.Alias == @"..\evil" && !i.Written && i.Error != null);
+        result.Items.Should().ContainSingle(i => i.Alias == unsafeAlias && !i.Written && i.Error != null);
         File.Exists(Path.Join(_contentRoot, "uSync", "evil.config")).Should().BeFalse();
     }
 

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingExporterTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/USync/USyncMappingExporterTests.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Community.SchemeWeaver.Tests.Unit.USync;
 
 public class USyncMappingExporterTests : IDisposable
 {
-    private readonly string _contentRoot = Path.Combine(Path.GetTempPath(), "sw-export-" + Guid.NewGuid().ToString("N"));
+    private readonly string _contentRoot = Path.Join(Path.GetTempPath(), "sw-export-" + Guid.NewGuid().ToString("N"));
     private readonly ISchemaMappingRepository _repository = Substitute.For<ISchemaMappingRepository>();
     private readonly IHostEnvironment _hostEnvironment = Substitute.For<IHostEnvironment>();
 
@@ -66,8 +66,8 @@ public class USyncMappingExporterTests : IDisposable
         result.UsyncAvailable.Should().BeTrue();
         result.Items.Should().HaveCount(2);
         result.Items.Should().OnlyContain(i => i.Written);
-        File.Exists(Path.Combine(result.Folder!, "article.config")).Should().BeTrue();
-        File.Exists(Path.Combine(result.Folder!, "newsItem.config")).Should().BeTrue();
+        File.Exists(Path.Join(result.Folder!, "article.config")).Should().BeTrue();
+        File.Exists(Path.Join(result.Folder!, "newsItem.config")).Should().BeTrue();
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class USyncMappingExporterTests : IDisposable
         var result = exporter.Export("article");
 
         result.Items.Should().ContainSingle(i => i.Alias == "article" && i.Written);
-        File.Exists(Path.Combine(result.Folder!, "article.config")).Should().BeTrue();
+        File.Exists(Path.Join(result.Folder!, "article.config")).Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Validation/Rules/JobPostingRuleTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Validation/Rules/JobPostingRuleTests.cs
@@ -136,10 +136,6 @@ public class JobPostingRuleTests
     [Fact]
     public void Check_HiringOrganizationWithoutName_ProducesCritical()
     {
-        var json = FullyPopulated.Replace(
-            "\"hiringOrganization\": {\n    \"@type\": \"Organization\",\n    \"name\": \"Example Co\",\n    \"sameAs\": \"https://example.com\"\n  },",
-            "\"hiringOrganization\": { \"@type\": \"Organization\" },");
-        // Replace may not have matched due to whitespace; do a tolerant swap instead.
         var withBrokenHiringOrg = """
             {
               "@type": "JobPosting",


### PR DESCRIPTION
Clears every open GitHub Code Quality finding, AI finding, and Dependabot vulnerability alert in one sweep, executed by parallel workstreams with two adversarial (devil's-advocate) review gates, and verified end-to-end against a live TestHost.

## Dependencies (all 44 alerts addressed)

- **Frontend (App_Plugins/SchemeWeaver)** — lockfile-only, in-range bumps: vite 8.1.2, markdown-it 14.2.0, postcss 8.5.16, qs 6.15.3, ip-address 10.2.0, js-yaml 4.2.0, ws patched. `@umbraco-cms/backoffice` deliberately unmoved (its pin tracks the supported Umbraco version). Meets or exceeds every open Dependabot PR target, so those PRs auto-close.
- **MCP server** — undici → 7.28.0 (floor bumped), esbuild → 0.28.1, js-yaml → 4.3.0, lodash → 4.18.1 via scoped `overrides`; committed `dist/index.js` rebuilt (6-line esbuild helper change only — undici turns out to be test-only, never bundled). `@scarf/scarf` telemetry pulled in by the spectral-functions bump is disabled via the package.json `scarf` field.
- **AI satellite** — dompurify → 3.4.11 everywhere (a scoped `monaco-editor > dompurify` override defeats monaco's exact 3.2.7 pin), js-yaml → 4.2.0.
- **Accepted residual**: esbuild 0.27.7 under `@web/dev-server-esbuild` (GHSA-g7r4-m6w7-qqqr, LOW, dev-server-only) — no in-range fix exists; will be dismissed as tolerable risk.

## Code Quality findings (166 standard + 6 AI)

- **Exception-handling**: the ~15 identical catch→LogError→500 blocks in `SchemeWeaverApiController` are replaced by one `HandlesServerErrorAttribute` exception filter. The wire contract is frozen (same `{ error: "An unexpected error occurred whilst <operation>." }` bodies, same 500s) and pinned by new unit tests; route values + query string are logged so no observability is lost. Endpoints that returned lazy enumerables now materialise inside the guarded region (previously a throwing enumeration bypassed the 500 contract at serialization time).
- **Silent catches now log**: `SchemaAutoMapper` (naked catch) and `StructuralEnricher` (comment-only) gained optional loggers; `BlockContentResolver` logs when the recursion-depth cap skips a block.
- **Path handling**: all 24 `Path.Combine` → `Path.Join`; `MappingFileWriter` now **rejects** aliases that aren't plain file names (logged; export result reports `written: false` + error) instead of writing outside the mappings folder; drift detection shares the same `IsSafeAlias` check so unsafe aliases report `DbOnly` without out-of-folder probes.
- **LINQ**: 21 semantics-preserving foreach→Where/Select/Any conversions in src (each verified for laziness/mutation/ordering parity by the review gate); deliberately-imperative sites (stackalloc hot path, yield iterators, out-var guards, async recursion) left alone and will be dismissed with reasons.
- **Razor**: 22 `?.X == true` → `?.X is true` in TestHost views (CodeQL's literal suggestion wouldn't compile for `bool?`).
- **Small fixes**: `TryGetPropertyValue` in GraphGenerator, two nested-if merges, `TryParseDateOrNumber(Type[]` → `IReadOnlyList<Type>`, dead test variable removed, 8× `EventMessages` disposed in tests, `OneOrMany<Uri>` property type pinned in a test, docs "two commands" → "three commands".
- **Hardening beyond the findings** (from the review gates): `JsonLdBlocksProvider` dispose races on both the global and per-content cancellation tokens are now retried/bounded instead of throwing into Delivery API requests.

## Behaviour notes

- **Unsafe mapping aliases** (path separators / traversal / invalid filename chars) are now refused by the uSync export writer with a logged warning and an honest `written: false` in the export result. Legitimate Umbraco aliases are unaffected.
- No package versions bumped; no API surface removed. The error-handling policy is now documented in CLAUDE.md.

## Verification

- C# suite: **918 passed / 0 failed / 2 skipped** (baseline 914; +3 filter-contract tests, +1 alias-refusal test)
- Frontend: **240/240** in both normal and MSW modes; bundle cache-bust stamp refreshed for the new vite output
- MCP: compile + build green; **47/47 jest integration tests against a live TestHost** (bearer-token path through every refactored endpoint)
- Playwright E2E: **41 passed** against a live TestHost, covering every mapping CRUD / auto-map / preview / validation / doc-type-generation flow through the refactored endpoints on the cookie-auth path. The 2 failures are pre-existing environment gaps the diff cannot influence: the AI satellite is compiled only into Umbraco-17 TestHost builds (`/ai/status` is 404 by design on an 18 host), and the `nestedBlocksPage` demo node isn't published in the long-lived dev database (8 conditionally skipped, 3 not run after the AI failure)
- Two devil's-advocate gates: triage review before any edits; full-diff adversarial review after the merge train (4 findings, all fixed and re-tested)

## Follow-ups (deliberate non-scope)

- API-level `SaveMapping` validation that the content-type alias exists (would flip three frozen integration-test expectations; the traversal risk is already closed at the writer)
- After merge: dismiss the intentional CodeQL findings (~48) with reasons in the Code Quality UI; reconcile the Dependabot alert list; close stale PRs #2/#3/#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
