### PR TITLE
refactor: reduce all 10 CC>20 hotspots (behaviour-preserving) + SourceTypes constants

### DIFF
--- a/src/Umbraco.Community.SchemeWeaver.AI/Tools/SaveSchemaMappingTool.cs
+++ b/src/Umbraco.Community.SchemeWeaver.AI/Tools/SaveSchemaMappingTool.cs
@@ -30,7 +30,7 @@ public record SaveSchemaMappingPropertyArg(
         "How to resolve the value. Use 'property' to read from a property on the current content node " +
         "(including built-ins __name, __url, __createDate, __updateDate). " +
         "Use 'static' to store a hardcoded literal value — set staticValue instead of contentTypePropertyAlias.")]
-    string SourceType = "property",
+    string SourceType = SchemeWeaverConstants.SourceTypes.Property,
     [property: Description("The hardcoded literal value to store when sourceType is 'static' (e.g., 'en-GB', 'https://schema.org/InStock').")]
     string? StaticValue = null);
 
@@ -77,7 +77,7 @@ public class SaveSchemaMappingTool : AIToolBase<SaveSchemaMappingArgs>
                 IsEnabled = true,
                 IsInherited = false,
                 PropertyMappings = args.PropertyMappings
-                    .Where(p => !string.IsNullOrEmpty(p.ContentTypePropertyAlias) || p.SourceType == "static")
+                    .Where(p => !string.IsNullOrEmpty(p.ContentTypePropertyAlias) || p.SourceType == SchemeWeaverConstants.SourceTypes.Static)
                     .Select(p => new PropertyMappingDto
                     {
                         SchemaPropertyName = p.SchemaPropertyName,

--- a/src/Umbraco.Community.SchemeWeaver.uSync/SchemaMappingSerializer.cs
+++ b/src/Umbraco.Community.SchemeWeaver.uSync/SchemaMappingSerializer.cs
@@ -108,53 +108,85 @@ public class SchemaMappingSerializer : SyncSerializerRoot<SchemaMapping>, ISyncS
             return Task.FromResult(SyncAttempt<SchemaMapping>.Fail(
                 node.Name.LocalName, ChangeType.Fail, "Missing Info element"));
 
-        var alias = info.Element("ContentTypeAlias")?.Value ?? string.Empty;
-        var key = Guid.Parse(info.Element("ContentTypeKey")?.Value ?? Guid.Empty.ToString());
-        var schemaTypeName = info.Element("SchemaTypeName")?.Value ?? string.Empty;
-        var isEnabled = bool.Parse(info.Element("IsEnabled")?.Value ?? "false");
-        var isInherited = bool.Parse(info.Element("IsInherited")?.Value ?? "false");
+        var alias = ElemOr(info, "ContentTypeAlias", string.Empty);
 
-        // Find existing or create new
+        // Idempotent upsert: find the existing mapping by alias so a re-import
+        // updates in place (preserving its DB Id) rather than duplicating.
         var existing = repository.GetByContentTypeAlias(alias);
-        var mapping = existing ?? new SchemaMapping();
+        var mapping = ReadMapping(info, existing ?? new SchemaMapping());
 
-        mapping.ContentTypeAlias = alias;
-        mapping.ContentTypeKey = key;
-        mapping.SchemaTypeName = schemaTypeName;
-        mapping.IsEnabled = isEnabled;
-        mapping.IsInherited = isInherited;
-        mapping.IdOverride = info.Element("IdOverride")?.Value;
-
+        // Save first: the returned Id is the FK (SchemaMappingId) the child
+        // PropertyMappings need, so it MUST run before they are built.
         var saved = repository.Save(mapping);
 
-        // Deserialize property mappings
-        var propertyMappingsNode = node.Element("PropertyMappings");
-        var propertyMappings = new List<PropertyMapping>();
-
-        if (propertyMappingsNode is not null)
-        {
-            propertyMappings.AddRange(propertyMappingsNode.Elements("PropertyMapping").Select(pmNode => new PropertyMapping
-            {
-                SchemaMappingId = saved.Id,
-                SchemaPropertyName = pmNode.Element("SchemaPropertyName")?.Value ?? string.Empty,
-                SourceType = pmNode.Element("SourceType")?.Value ?? "property",
-                ContentTypePropertyAlias = pmNode.Element("ContentTypePropertyAlias")?.Value,
-                SourceContentTypeAlias = pmNode.Element("SourceContentTypeAlias")?.Value,
-                TransformType = pmNode.Element("TransformType")?.Value,
-                IsAutoMapped = bool.Parse(pmNode.Element("IsAutoMapped")?.Value ?? "false"),
-                StaticValue = pmNode.Element("StaticValue")?.Value,
-                NestedSchemaTypeName = pmNode.Element("NestedSchemaTypeName")?.Value,
-                ResolverConfig = pmNode.Element("ResolverConfig")?.Value,
-                DynamicRootConfig = pmNode.Element("DynamicRootConfig")?.Value,
-                TargetPieceKey = pmNode.Element("TargetPieceKey")?.Value,
-            }));
-        }
+        // Full-replace: build the (possibly empty) child set and hand it over
+        // unconditionally, so an entry with no <PropertyMappings> clears the
+        // existing rows.
+        var propertyMappings = node.Element("PropertyMappings")
+            ?.Elements("PropertyMapping")
+            .Select(pmNode => ReadPropertyMapping(pmNode, saved.Id))
+            .ToList()
+            ?? new List<PropertyMapping>();
 
         repository.SavePropertyMappings(saved.Id, propertyMappings);
 
         return Task.FromResult(SyncAttempt<SchemaMapping>.Succeed(
             alias, saved, ChangeType.Import, new List<uSyncChange>()));
     }
+
+    /// <summary>
+    /// Reads the header (<c>&lt;Info&gt;</c>) fields onto <paramref name="target"/>.
+    /// Load-bearing defaults: empty string for alias/schema type, <see cref="Guid.Empty"/>
+    /// for the key, and <c>false</c> for the booleans (see <see cref="ElemBool"/>).
+    /// </summary>
+    private static SchemaMapping ReadMapping(XElement info, SchemaMapping target)
+    {
+        target.ContentTypeAlias = ElemOr(info, "ContentTypeAlias", string.Empty);
+        target.ContentTypeKey = ElemGuid(info, "ContentTypeKey");
+        target.SchemaTypeName = ElemOr(info, "SchemaTypeName", string.Empty);
+        target.IsEnabled = ElemBool(info, "IsEnabled");
+        target.IsInherited = ElemBool(info, "IsInherited");
+        target.IdOverride = Elem(info, "IdOverride");
+        return target;
+    }
+
+    /// <summary>
+    /// Projects a single <c>&lt;PropertyMapping&gt;</c> node onto a
+    /// <see cref="PropertyMapping"/>, wiring <paramref name="mappingId"/> as the FK.
+    /// A missing <c>&lt;SourceType&gt;</c> defaults to
+    /// <see cref="SchemeWeaverConstants.SourceTypes.Property"/> ("property"), not empty.
+    /// </summary>
+    private static PropertyMapping ReadPropertyMapping(XElement pmNode, int mappingId) => new()
+    {
+        SchemaMappingId = mappingId,
+        SchemaPropertyName = ElemOr(pmNode, "SchemaPropertyName", string.Empty),
+        SourceType = ElemOr(pmNode, "SourceType", SchemeWeaverConstants.SourceTypes.Property),
+        ContentTypePropertyAlias = Elem(pmNode, "ContentTypePropertyAlias"),
+        SourceContentTypeAlias = Elem(pmNode, "SourceContentTypeAlias"),
+        TransformType = Elem(pmNode, "TransformType"),
+        IsAutoMapped = ElemBool(pmNode, "IsAutoMapped"),
+        StaticValue = Elem(pmNode, "StaticValue"),
+        NestedSchemaTypeName = Elem(pmNode, "NestedSchemaTypeName"),
+        ResolverConfig = Elem(pmNode, "ResolverConfig"),
+        DynamicRootConfig = Elem(pmNode, "DynamicRootConfig"),
+        TargetPieceKey = Elem(pmNode, "TargetPieceKey"),
+    };
+
+    /// <summary>Child element text, or <paramref name="fallback"/> when the element is absent.</summary>
+    private static string ElemOr(XElement node, string name, string fallback) =>
+        node.Element(name)?.Value ?? fallback;
+
+    /// <summary>Child element text, or <c>null</c> when the element is absent (nullable columns).</summary>
+    private static string? Elem(XElement node, string name) =>
+        node.Element(name)?.Value;
+
+    /// <summary>Child element parsed as a bool, defaulting to <c>false</c> when absent.</summary>
+    private static bool ElemBool(XElement node, string name) =>
+        bool.Parse(node.Element(name)?.Value ?? "false");
+
+    /// <summary>Child element parsed as a <see cref="Guid"/>, defaulting to <see cref="Guid.Empty"/> when absent.</summary>
+    private static Guid ElemGuid(XElement node, string name) =>
+        Guid.Parse(node.Element(name)?.Value ?? Guid.Empty.ToString());
 
     public override Task<SchemaMapping?> FindItemAsync(Guid key)
     {

--- a/src/Umbraco.Community.SchemeWeaver/Models/Entities/PropertyMapping.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Models/Entities/PropertyMapping.cs
@@ -22,7 +22,7 @@ public class PropertyMapping
     public string SchemaPropertyName { get; set; } = string.Empty;
 
     [Column("SourceType")]
-    public string SourceType { get; set; } = "property";
+    public string SourceType { get; set; } = SchemeWeaverConstants.SourceTypes.Property;
 
     [Column("ContentTypePropertyAlias")]
     [NullSetting(NullSetting = NullSettings.Null)]

--- a/src/Umbraco.Community.SchemeWeaver/Notifications/JsonLdCacheInvalidator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Notifications/JsonLdCacheInvalidator.cs
@@ -22,9 +22,6 @@ namespace Umbraco.Community.SchemeWeaver.Notifications;
 /// </summary>
 internal static class JsonLdCacheInvalidator
 {
-    private static readonly HashSet<string> CrossNodeSourceTypes =
-        new(StringComparer.OrdinalIgnoreCase) { "ancestor", "parent", "sibling", "reference" };
-
     public static void InvalidateTree(
         IJsonLdBlocksProvider provider,
         ISchemaMappingRepository mappingRepository,
@@ -104,7 +101,7 @@ internal static class JsonLdCacheInvalidator
 
             return repo.GetAllPropertyMappingsByMappingId().Values
                 .SelectMany(list => list)
-                .Any(p => CrossNodeSourceTypes.Contains(p.SourceType));
+                .Any(p => SchemeWeaverConstants.SourceTypes.IsCrossNode(p.SourceType));
         }
         catch (Exception ex)
         {

--- a/src/Umbraco.Community.SchemeWeaver/SchemeWeaverConstants.cs
+++ b/src/Umbraco.Community.SchemeWeaver/SchemeWeaverConstants.cs
@@ -85,4 +85,66 @@ public static class SchemeWeaverConstants
             "Umbraco.MarkdownEditor"
         };
     }
+
+    /// <summary>
+    /// Source-type discriminators for a <see cref="Models.Entities.PropertyMapping"/> — they say
+    /// where a Schema.org property's value comes from. Persisted verbatim (author-controlled, always
+    /// lowercase). These constants are the single source of truth for the string literals that were
+    /// previously duplicated across the resolver, auto-mapper, validation, advisory, enrichment,
+    /// serialization and AI layers.
+    /// </summary>
+    /// <remarks>
+    /// The render path (<see cref="Services.JsonLdGenerator"/>, auto-mapper defaults) compares these
+    /// with case-sensitive <c>==</c>/<c>switch</c>; the advisory/validation/enrichment paths use
+    /// <c>OrdinalIgnoreCase</c>. Swapping a literal for the matching constant preserves the value, so
+    /// each call site keeps its existing comparison policy unchanged.
+    /// </remarks>
+    public static class SourceTypes
+    {
+        /// <summary>A scalar or media value read from a property on the current node (the default).</summary>
+        public const string Property = "property";
+
+        /// <summary>A fixed literal value stored on the mapping (<c>StaticValue</c>).</summary>
+        public const string Static = "static";
+
+        /// <summary>A nested Schema.org entity resolved from a complex-type configuration.</summary>
+        public const string ComplexType = "complexType";
+
+        /// <summary>A nested Schema.org entity (or entities) resolved from a Block List / Block Grid.</summary>
+        public const string BlockContent = "blockContent";
+
+        /// <summary>A shared graph piece referenced by key (emits a range-typed <c>@id</c> shell).</summary>
+        public const string Reference = "reference";
+
+        /// <summary>A value read from the parent node.</summary>
+        public const string Parent = "parent";
+
+        /// <summary>A value read from an ancestor node.</summary>
+        public const string Ancestor = "ancestor";
+
+        /// <summary>A value read from a sibling node.</summary>
+        public const string Sibling = "sibling";
+
+        private static readonly HashSet<string> CrossNode =
+            new(StringComparer.OrdinalIgnoreCase) { Parent, Ancestor, Sibling, Reference };
+
+        private static readonly HashSet<string> NestedThing =
+            new(StringComparer.OrdinalIgnoreCase) { ComplexType, BlockContent };
+
+        /// <summary>
+        /// Source types whose value is resolved from a node other than the current one
+        /// (<see cref="Parent"/>, <see cref="Ancestor"/>, <see cref="Sibling"/>, <see cref="Reference"/>).
+        /// A change to such a source can invalidate JSON-LD cached against a different node, so the
+        /// cache invalidator fans out across relationships for these. Compared case-insensitively.
+        /// </summary>
+        public static bool IsCrossNode(string? sourceType) =>
+            sourceType is not null && CrossNode.Contains(sourceType);
+
+        /// <summary>
+        /// Source types that resolve to a nested Schema.org <c>Thing</c> rather than a scalar
+        /// (<see cref="ComplexType"/>, <see cref="BlockContent"/>). Compared case-insensitively.
+        /// </summary>
+        public static bool ResolvesToNestedThing(string? sourceType) =>
+            sourceType is not null && NestedThing.Contains(sourceType);
+    }
 }

--- a/src/Umbraco.Community.SchemeWeaver/Services/Advisory/MappingAdvisor.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Advisory/MappingAdvisor.cs
@@ -43,73 +43,92 @@ public sealed class MappingAdvisor : IMappingAdvisor
 
     public IReadOnlyList<MappingAdvice> AdviseEntry(MappingEntryInput entry)
     {
-        var advices = new List<MappingAdvice>();
         if (entry is null
             || string.IsNullOrWhiteSpace(entry.SchemaTypeName)
             || string.IsNullOrWhiteSpace(entry.SchemaPropertyName))
-            return advices;
+            return [];
 
         var schemaProps = _registry.GetProperties(entry.SchemaTypeName).ToList();
         if (schemaProps.Count == 0)
-            return advices;
+            return [];
 
         var targetProp = schemaProps.FirstOrDefault(p =>
             string.Equals(p.Name, entry.SchemaPropertyName, StringComparison.OrdinalIgnoreCase));
 
         var config = ParseConfig(entry.ResolverConfig);
 
-        // Check 1 — an HTML-producing source feeds a plain-text target with no transform.
-        if (targetProp is not null
-            && string.Equals(entry.SourceType, "property", StringComparison.OrdinalIgnoreCase)
-            && entry.ContentEditorAlias is { } editor
-            && SchemeWeaverConstants.PropertyEditors.HtmlProducingEditorAliases.Contains(editor)
-            && SchemaPrimitiveTypes.IsPlainTextRange(targetProp.AcceptedTypes)
-            && !string.Equals(entry.TransformType, "stripHtml", StringComparison.OrdinalIgnoreCase)
-            && !HtmlAllowedProperties.Contains(entry.SchemaPropertyName))
+        // Three independent checks, always all evaluated; emission order is fixed
+        // (StripHtml, then WrapInListItem, then MissingRequired).
+        var advices = new List<MappingAdvice>();
+        advices.AddRange(AdviseStripHtml(entry, targetProp));
+        advices.AddRange(AdviseWrapInListItem(entry, targetProp, config));
+        advices.AddRange(AdviseMissingRequired(entry, config));
+        return advices;
+    }
+
+    // Check 1 — an HTML-producing source feeds a plain-text target with no transform.
+    private static IEnumerable<MappingAdvice> AdviseStripHtml(MappingEntryInput entry, SchemaPropertyInfo? targetProp)
+    {
+        if (targetProp is null
+            || !string.Equals(entry.SourceType, SchemeWeaverConstants.SourceTypes.Property, StringComparison.OrdinalIgnoreCase)
+            || !SchemaPrimitiveTypes.IsPlainTextRange(targetProp.AcceptedTypes)
+            || string.Equals(entry.TransformType, "stripHtml", StringComparison.OrdinalIgnoreCase)
+            || HtmlAllowedProperties.Contains(entry.SchemaPropertyName))
+            yield break;
+
+        if (entry.ContentEditorAlias is { } editor
+            && SchemeWeaverConstants.PropertyEditors.HtmlProducingEditorAliases.Contains(editor))
         {
-            advices.Add(new MappingAdvice(
+            yield return new MappingAdvice(
                 MappingAdviceKind.StripHtml, entry.SchemaTypeName, entry.SchemaPropertyName,
                 $"'{entry.SchemaPropertyName}' is fed by a rich-text editor ({editor}) but accepts plain text — " +
                 "it will emit raw HTML. Set transformType:'stripHtml' to emit clean text.",
-                new MappingAdviceFix(TransformType: "stripHtml")));
+                new MappingAdviceFix(TransformType: "stripHtml"));
         }
+    }
 
-        // Check 2 — a block list feeds an ordered-list property without ListItem wrapping.
-        if (targetProp is not null
-            && string.Equals(entry.SourceType, "blockContent", StringComparison.OrdinalIgnoreCase)
-            && IsOrderedListProperty(entry.SchemaPropertyName, targetProp.AcceptedTypes)
-            && config is not null
-            && !string.Equals(config.ExtractAs, "stringList", StringComparison.OrdinalIgnoreCase)
-            && HasRoutes(config)
-            && !config.WrapInListItem)
+    // Check 2 — a block list feeds an ordered-list property without ListItem wrapping.
+    private static IEnumerable<MappingAdvice> AdviseWrapInListItem(
+        MappingEntryInput entry, SchemaPropertyInfo? targetProp, ResolverConfigModel? config)
+    {
+        if (targetProp is null
+            || config is null
+            || !string.Equals(entry.SourceType, SchemeWeaverConstants.SourceTypes.BlockContent, StringComparison.OrdinalIgnoreCase)
+            || !IsOrderedListProperty(entry.SchemaPropertyName, targetProp.AcceptedTypes)
+            || string.Equals(config.ExtractAs, "stringList", StringComparison.OrdinalIgnoreCase)
+            || !HasRoutes(config)
+            || config.WrapInListItem)
+            yield break;
+
+        yield return new MappingAdvice(
+            MappingAdviceKind.WrapInListItem, entry.SchemaTypeName, entry.SchemaPropertyName,
+            $"'{entry.SchemaPropertyName}' is an ordered list but its blocks are not wrapped as ListItems — " +
+            "they emit without positions. Set wrapInListItem:true (optionally positionProperty) for an ordered ItemList.",
+            new MappingAdviceFix(WrapInListItem: true));
+    }
+
+    // Check 3 — a known rich-result nested type is missing a required property.
+    private static IEnumerable<MappingAdvice> AdviseMissingRequired(MappingEntryInput entry, ResolverConfigModel? config)
+    {
+        if (config is null)
+            yield break;
+
+        if (config.Routes is { Count: > 0 } routes)
         {
-            advices.Add(new MappingAdvice(
-                MappingAdviceKind.WrapInListItem, entry.SchemaTypeName, entry.SchemaPropertyName,
-                $"'{entry.SchemaPropertyName}' is an ordered list but its blocks are not wrapped as ListItems — " +
-                "they emit without positions. Set wrapInListItem:true (optionally positionProperty) for an ordered ItemList.",
-                new MappingAdviceFix(WrapInListItem: true)));
+            foreach (var route in routes.Where(r => !string.IsNullOrWhiteSpace(r.NestedSchemaType)))
+            {
+                foreach (var advice in MissingRequiredForRoute(entry, route.NestedSchemaType!, route.BlockAlias,
+                             route.PropertyMappings?.Select(m => m.SchemaProperty)))
+                    yield return advice;
+            }
         }
-
-        // Check 3 — a known rich-result nested type is missing a required property.
-        if (config is not null)
+        else if (config.NestedMappings is { Count: > 0 } legacy
+                 && !string.IsNullOrWhiteSpace(entry.NestedSchemaTypeName))
         {
-            if (config.Routes is { Count: > 0 } routes)
-            {
-                foreach (var route in routes.Where(r => !string.IsNullOrWhiteSpace(r.NestedSchemaType)))
-                {
-                    AddMissingRequiredForRoute(entry, route.NestedSchemaType!, route.BlockAlias,
-                        route.PropertyMappings?.Select(m => m.SchemaProperty), advices);
-                }
-            }
-            else if (config.NestedMappings is { Count: > 0 } legacy
-                     && !string.IsNullOrWhiteSpace(entry.NestedSchemaTypeName))
-            {
-                AddMissingRequiredForRoute(entry, entry.NestedSchemaTypeName!, blockAlias: null,
-                    legacy.Select(m => m.SchemaProperty), advices);
-            }
+            foreach (var advice in MissingRequiredForRoute(entry, entry.NestedSchemaTypeName!, blockAlias: null,
+                         legacy.Select(m => m.SchemaProperty)))
+                yield return advice;
         }
-
-        return advices;
     }
 
     public MappingAdvice? AdvisePersistence(string schemaTypeName, PersistenceFacts facts)
@@ -138,15 +157,14 @@ public sealed class MappingAdvisor : IMappingAdvisor
     /// mappings do not cover. Advisory-only (no fix) — the author must choose which block property
     /// supplies the value.
     /// </summary>
-    private static void AddMissingRequiredForRoute(
+    private static IEnumerable<MappingAdvice> MissingRequiredForRoute(
         MappingEntryInput entry,
         string nestedType,
         string? blockAlias,
-        IEnumerable<string?>? mappedProperties,
-        List<MappingAdvice> advices)
+        IEnumerable<string?>? mappedProperties)
     {
         if (!RequiredNestedProperties.TryGetValue(nestedType, out var required))
-            return;
+            yield break;
 
         var covered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (mappedProperties is not null)
@@ -159,10 +177,10 @@ public sealed class MappingAdvisor : IMappingAdvisor
 
         foreach (var requiredProp in required.Where(p => !covered.Contains(p)))
         {
-            advices.Add(new MappingAdvice(
+            yield return new MappingAdvice(
                 MappingAdviceKind.MissingRequiredNestedProperty, entry.SchemaTypeName, entry.SchemaPropertyName,
                 $"{prefix}{nestedType} does not map '{requiredProp}', which Google's rich result requires — " +
-                $"map it on the route (e.g. the block property holding the {requiredProp})."));
+                $"map it on the route (e.g. the block property holding the {requiredProp}).");
         }
     }
 

--- a/src/Umbraco.Community.SchemeWeaver/Services/BlockSchemaSuggester.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/BlockSchemaSuggester.cs
@@ -233,7 +233,7 @@ public class BlockSchemaSuggester : IBlockSchemaSuggester
         // schema properties it already mapped.
         foreach (var s in suggestions.Where(s =>
                      !string.IsNullOrEmpty(s.SuggestedContentTypePropertyAlias)
-                     && string.Equals(s.SuggestedSourceType, "property", StringComparison.OrdinalIgnoreCase)
+                     && string.Equals(s.SuggestedSourceType, SchemeWeaverConstants.SourceTypes.Property, StringComparison.OrdinalIgnoreCase)
                      && !s.SuggestedContentTypePropertyAlias.StartsWith(SchemeWeaverConstants.BuiltInProperties.Prefix, StringComparison.Ordinal)
                      && !covered.Contains(s.SchemaPropertyName)))
         {

--- a/src/Umbraco.Community.SchemeWeaver/Services/JsonLdGenerator.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/JsonLdGenerator.cs
@@ -105,73 +105,25 @@ public partial class JsonLdGenerator : IJsonLdGenerator
         if (Activator.CreateInstance(clrType) is not Thing instance)
             return null;
 
-        var propertyMappings = _repository.GetPropertyMappings(mapping.Id);
-        var hasExplicitInLanguage = false;
+        // Materialise once so the InLanguage precompute and the mapping loop share one snapshot.
+        var propertyMappings = _repository.GetPropertyMappings(mapping.Id).ToList();
+
+        // An explicit InLanguage mapping (of any source type) suppresses the post-loop auto-fill.
+        // The original signalled this from inside the loop before resolving the mapping, so its
+        // presence — not its resolved value — is what matters; precompute it up front.
+        var hasExplicitInLanguage = propertyMappings.Any(pm =>
+            string.Equals(pm.SchemaPropertyName, "InLanguage", StringComparison.OrdinalIgnoreCase));
         var hasExplicitId = false;
 
         foreach (var propMapping in propertyMappings)
         {
+            // Per-property try/catch is the degrade boundary: one bad property logs a
+            // warning and the rest of the Thing is still built. Keep it INSIDE the loop.
             try
             {
-                if (string.Equals(propMapping.SchemaPropertyName, "InLanguage", StringComparison.OrdinalIgnoreCase))
-                    hasExplicitInLanguage = true;
-
-                // `reference` source type: cross-piece @id ref. Only resolvable
-                // when called inside the graph pipeline (graphContext != null).
-                // Outside that pipeline (legacy single-Thing callers) we can't
-                // know what to point at, so the mapping is skipped.
-                if (string.Equals(propMapping.SourceType, "reference", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (graphContext is null || string.IsNullOrWhiteSpace(propMapping.TargetPieceKey))
-                        continue;
-
-                    var refId = graphContext.IdFor(propMapping.TargetPieceKey);
-                    if (string.IsNullOrWhiteSpace(refId)
-                        || !Uri.TryCreate(refId, UriKind.Absolute, out var refUri))
-                        continue;
-
-                    // @id-only shell typed to the target property's range so it
-                    // binds even to narrowly-typed properties (e.g. publisher
-                    // needs an Organization, not a bare Thing). GraphGenerator's
-                    // ref-collapse then reduces the serialised form to {"@id": …}.
-                    SchemaPropertySetter.SetPropertyValue(
-                        instance,
-                        propMapping.SchemaPropertyName,
-                        SchemaPropertySetter.CreateReferenceShell(
-                            instance, propMapping.SchemaPropertyName, refUri));
-                    continue;
-                }
-
-                var value = ResolveValue(propMapping, content, culture);
-                if (value is null)
-                    continue;
-
-                // Apply transforms only to string values; skip empty/whitespace
-                if (value is string stringValue)
-                {
-                    if (string.IsNullOrWhiteSpace(stringValue))
-                        continue;
-                    value = ApplyTransform(stringValue, propMapping.TransformType);
-                }
-
-                // Guard against null after transform (ApplyTransform can return null)
-                if (value is null or string { Length: 0 })
-                    continue;
-
-                // @id is Uri-typed on Schema.NET Thing; SchemaPropertySetter can't convert a
-                // string to Uri generically, so we handle it here. Setting via mapping
-                // suppresses the default {url}#{type} convention below.
-                if (string.Equals(propMapping.SchemaPropertyName, "Id", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (TryCoerceToUri(value, out var idUri))
-                    {
-                        instance.Id = idUri;
-                        hasExplicitId = true;
-                    }
-                    continue;
-                }
-
-                SchemaPropertySetter.SetPropertyValue(instance, propMapping.SchemaPropertyName, value);
+                if (ApplyPropertyMapping(instance, propMapping, content, culture, graphContext)
+                    == PropertyMappingOutcome.SetExplicitId)
+                    hasExplicitId = true;
             }
             catch (Exception ex)
             {
@@ -202,6 +154,111 @@ public partial class JsonLdGenerator : IJsonLdGenerator
         }
 
         return instance;
+    }
+
+    /// <summary>
+    /// Outcome of applying a single <see cref="PropertyMapping"/> to the top-level Thing. Lets the
+    /// caller learn whether an explicit <c>@id</c> was set WITHOUT a <c>ref</c> flag, while keeping the
+    /// per-property try/catch (the degrade boundary) in the parent loop.
+    /// </summary>
+    private enum PropertyMappingOutcome
+    {
+        /// <summary>Nothing was applied (null/empty resolution, unresolvable reference, or an Id that would not coerce).</summary>
+        Skipped,
+
+        /// <summary>A normal schema property (or reference shell) was set on the instance.</summary>
+        Set,
+
+        /// <summary>An explicit <c>Id</c> mapping coerced to a Uri and was set — suppresses the default <c>@id</c> convention.</summary>
+        SetExplicitId
+    }
+
+    /// <summary>
+    /// Applies a single property mapping to <paramref name="instance"/>. Mirrors the original loop
+    /// body exactly (reference short-circuit before ResolveValue; transform only on strings; the
+    /// explicit-Id branch); the caller wraps this in the per-property try/catch.
+    /// </summary>
+    private PropertyMappingOutcome ApplyPropertyMapping(
+        Thing instance,
+        PropertyMapping propMapping,
+        IPublishedContent content,
+        string? culture,
+        GraphPieceContext? graphContext)
+    {
+        // `reference` source type: cross-piece @id ref. Only resolvable when called inside the
+        // graph pipeline (graphContext != null). Outside that pipeline (legacy single-Thing
+        // callers) we can't know what to point at, so the mapping is skipped. This must
+        // short-circuit BEFORE ResolveValue — references are resolved from the graph context.
+        if (string.Equals(propMapping.SourceType, SchemeWeaverConstants.SourceTypes.Reference, StringComparison.OrdinalIgnoreCase))
+            return TryApplyReference(instance, propMapping, graphContext);
+
+        var value = ResolveValue(propMapping, content, culture);
+        if (value is null)
+            return PropertyMappingOutcome.Skipped;
+
+        // Apply transforms only to string values; skip empty/whitespace
+        if (value is string stringValue)
+        {
+            if (string.IsNullOrWhiteSpace(stringValue))
+                return PropertyMappingOutcome.Skipped;
+            value = ApplyTransform(stringValue, propMapping.TransformType);
+        }
+
+        // Guard against null after transform (ApplyTransform can return null)
+        if (value is null or string { Length: 0 })
+            return PropertyMappingOutcome.Skipped;
+
+        // @id is Uri-typed on Schema.NET Thing; SchemaPropertySetter can't convert a
+        // string to Uri generically, so we handle it here. Setting via mapping
+        // suppresses the default {url}#{type} convention.
+        if (string.Equals(propMapping.SchemaPropertyName, "Id", StringComparison.OrdinalIgnoreCase))
+            return TryApplyExplicitId(instance, value);
+
+        SchemaPropertySetter.SetPropertyValue(instance, propMapping.SchemaPropertyName, value);
+        return PropertyMappingOutcome.Set;
+    }
+
+    /// <summary>
+    /// Handles a <c>reference</c> source-type mapping: resolves the target piece's absolute @id from
+    /// the graph context and binds a range-typed @id-only shell. Returns <see cref="PropertyMappingOutcome.Skipped"/>
+    /// when there is no graph context, no target key, or an unresolvable/relative id.
+    /// </summary>
+    private static PropertyMappingOutcome TryApplyReference(
+        Thing instance, PropertyMapping propMapping, GraphPieceContext? graphContext)
+    {
+        if (graphContext is null || string.IsNullOrWhiteSpace(propMapping.TargetPieceKey))
+            return PropertyMappingOutcome.Skipped;
+
+        var refId = graphContext.IdFor(propMapping.TargetPieceKey);
+        if (string.IsNullOrWhiteSpace(refId)
+            || !Uri.TryCreate(refId, UriKind.Absolute, out var refUri))
+            return PropertyMappingOutcome.Skipped;
+
+        // @id-only shell typed to the target property's range so it binds even to narrowly-typed
+        // properties (e.g. publisher needs an Organization, not a bare Thing). GraphGenerator's
+        // ref-collapse then reduces the serialised form to {"@id": …}.
+        SchemaPropertySetter.SetPropertyValue(
+            instance,
+            propMapping.SchemaPropertyName,
+            SchemaPropertySetter.CreateReferenceShell(
+                instance, propMapping.SchemaPropertyName, refUri));
+        return PropertyMappingOutcome.Set;
+    }
+
+    /// <summary>
+    /// Handles an explicit <c>Id</c> mapping: coerces the resolved value to a Uri (relative-or-absolute,
+    /// preserving fragment ids) and sets <see cref="Thing.Id"/>. Returns <see cref="PropertyMappingOutcome.SetExplicitId"/>
+    /// only when the value coerces — otherwise the default @id convention still applies.
+    /// </summary>
+    private static PropertyMappingOutcome TryApplyExplicitId(Thing instance, object value)
+    {
+        if (TryCoerceToUri(value, out var idUri))
+        {
+            instance.Id = idUri;
+            return PropertyMappingOutcome.SetExplicitId;
+        }
+
+        return PropertyMappingOutcome.Skipped;
     }
 
     public string? GenerateJsonLdString(IPublishedContent content, string? culture = null)
@@ -646,60 +703,19 @@ public partial class JsonLdGenerator : IJsonLdGenerator
         if (config?.ComplexTypeMappings is null or { Count: 0 })
             return null; // No sub-mappings configured — skip rather than emit empty object
 
-        // Resolve every sub-mapping up front so a resolved media ImageObject can be ADOPTED
-        // as the nested instance (see below) before any sub-value is applied to it.
+        // Two-phase (mandatory): resolve EVERY sub-mapping up front so a resolved media ImageObject
+        // can be ADOPTED as the nested instance (see TryAdoptImageObject) before any sub-value is
+        // applied to it. Adoption must inspect the full resolved list, so nothing is set until phase 2.
         var resolved = new List<(ComplexTypeMappingEntry SubMapping, object Value)>();
         foreach (var subMapping in config.ComplexTypeMappings.Where(m => !string.IsNullOrEmpty(m.SchemaProperty)))
         {
-            object? value = subMapping.SourceType switch
-            {
-                "static" => subMapping.StaticValue,
-                "property" when !string.IsNullOrEmpty(subMapping.ContentTypePropertyAlias) =>
-                    ResolveComplexTypePropertyValue(content, subMapping.ContentTypePropertyAlias, culture),
-                "complexType" when !string.IsNullOrEmpty(subMapping.ResolverConfig) =>
-                    ResolveNestedComplexType(subMapping, content, culture),
-                _ => null
-            };
-
-            // Apply an optional transform to a property-sourced string sub-value (e.g. stripHtml a
-            // RichText sub-property). static stays untransformed, mirroring the top-level static
-            // behaviour; complexType yields a Thing, not a string, so the guard skips it. A transform
-            // that collapses to whitespace drops the sub-value rather than emitting it blank.
-            if (value is string sv
-                && string.Equals(subMapping.SourceType, "property", StringComparison.OrdinalIgnoreCase)
-                && !string.IsNullOrEmpty(subMapping.TransformType))
-            {
-                var transformed = ApplyTransform(sv, subMapping.TransformType);
-                value = string.IsNullOrWhiteSpace(transformed) ? null : transformed;
-            }
-
+            var value = ResolveSubValue(subMapping, content, culture);
             if (value is not null)
                 resolved.Add((subMapping, value));
         }
 
-        // Render-time repair for persisted MediaPicker→ImageObject shapes: the auto-mapper +
-        // enricher historically persisted complexType/ImageObject configs binding e.g.
-        // ImageObject.Name <- the media alias. At render time the media resolves (via the
-        // resolver factory) to a FULL ImageObject that can never be assigned into a string-only
-        // sub-property — it would be silently dropped, leaving an empty {"@type":"ImageObject"}
-        // shell. Instead, adopt the first such resolved ImageObject AS the nested instance, then
-        // apply the remaining sub-mappings (e.g. static captions) on top of it.
-        // The adoption is strictly limited to that broken-shape case: a sub-property whose range
-        // DOES accept an ImageObject or URL (e.g. ImageObject.Thumbnail, contentUrl) is a valid
-        // config the setter handles — adopting it would hijack the intended structure (the
-        // thumbnail would masquerade as the whole image), so it is left to bind normally.
-        if (nestedInstance is ImageObject)
-        {
-            var adoptIndex = resolved.FindIndex(r =>
-                string.Equals(r.SubMapping.SourceType, "property", StringComparison.OrdinalIgnoreCase)
-                && FirstImageObject(r.Value) is not null
-                && !SchemaPropertySetter.PropertyAcceptsImageValue(nestedInstance, r.SubMapping.SchemaProperty));
-            if (adoptIndex >= 0)
-            {
-                nestedInstance = FirstImageObject(resolved[adoptIndex].Value)!;
-                resolved.RemoveAt(adoptIndex);
-            }
-        }
+        // Render-time repair for persisted MediaPicker→ImageObject shapes (see TryAdoptImageObject).
+        nestedInstance = TryAdoptImageObject(nestedInstance, resolved);
 
         foreach (var (subMapping, value) in resolved)
             SchemaPropertySetter.SetPropertyValue(nestedInstance, subMapping.SchemaProperty, value);
@@ -708,6 +724,70 @@ public partial class JsonLdGenerator : IJsonLdGenerator
         // instance (all resolved null, or every set was dropped by type conversion), omit
         // the nested Thing entirely — {"@type":"Person"} shells are invalid structured data.
         return SchemaPropertySetter.HasResolvedProperty(nestedInstance) ? nestedInstance : null;
+    }
+
+    /// <summary>
+    /// Resolves a single complex-type sub-mapping to its value: the 4-arm SourceType switch
+    /// (<c>static</c> / <c>property</c> / <c>complexType</c> / default) plus the transform
+    /// post-processing. The switch keeps this file's case-sensitive render-path comparison policy.
+    /// A transform applies ONLY to a property-sourced string (static stays untransformed; complexType
+    /// yields a Thing, not a string) and, when it collapses to whitespace, drops the sub-value.
+    /// </summary>
+    private object? ResolveSubValue(ComplexTypeMappingEntry subMapping, IPublishedContent content, string? culture)
+    {
+        object? value = subMapping.SourceType switch
+        {
+            SchemeWeaverConstants.SourceTypes.Static => subMapping.StaticValue,
+            SchemeWeaverConstants.SourceTypes.Property when !string.IsNullOrEmpty(subMapping.ContentTypePropertyAlias) =>
+                ResolveComplexTypePropertyValue(content, subMapping.ContentTypePropertyAlias, culture),
+            SchemeWeaverConstants.SourceTypes.ComplexType when !string.IsNullOrEmpty(subMapping.ResolverConfig) =>
+                ResolveNestedComplexType(subMapping, content, culture),
+            _ => null
+        };
+
+        if (value is string sv
+            && string.Equals(subMapping.SourceType, SchemeWeaverConstants.SourceTypes.Property, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrEmpty(subMapping.TransformType))
+        {
+            var transformed = ApplyTransform(sv, subMapping.TransformType);
+            value = string.IsNullOrWhiteSpace(transformed) ? null : transformed;
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Render-time repair for persisted MediaPicker→ImageObject shapes: the auto-mapper + enricher
+    /// historically persisted complexType/ImageObject configs binding e.g. ImageObject.Name &lt;- the
+    /// media alias. At render time the media resolves (via the resolver factory) to a FULL ImageObject
+    /// that can never be assigned into a string-only sub-property — it would be silently dropped,
+    /// leaving an empty {"@type":"ImageObject"} shell. Instead, adopt the first such resolved
+    /// ImageObject AS the nested instance (removing it from <paramref name="resolved"/> so it is not
+    /// re-applied), then let the caller apply the remaining sub-mappings (e.g. static captions) on top.
+    /// The adoption is strictly limited to that broken-shape case — the 3-clause guard requires a
+    /// <c>property</c>-sourced sub-mapping that resolves to an ImageObject AND whose target sub-property
+    /// does NOT accept an image. A sub-property whose range DOES accept an ImageObject or URL (e.g.
+    /// ImageObject.Thumbnail, contentUrl) is a valid config the setter handles — adopting it would
+    /// hijack the intended structure (the thumbnail would masquerade as the whole image), so it is
+    /// left to bind normally. Returns the (possibly adopted) instance.
+    /// </summary>
+    private static Thing TryAdoptImageObject(
+        Thing nestedInstance,
+        List<(ComplexTypeMappingEntry SubMapping, object Value)> resolved)
+    {
+        if (nestedInstance is not ImageObject)
+            return nestedInstance;
+
+        var adoptIndex = resolved.FindIndex(r =>
+            string.Equals(r.SubMapping.SourceType, SchemeWeaverConstants.SourceTypes.Property, StringComparison.OrdinalIgnoreCase)
+            && FirstImageObject(r.Value) is not null
+            && !SchemaPropertySetter.PropertyAcceptsImageValue(nestedInstance, r.SubMapping.SchemaProperty));
+        if (adoptIndex < 0)
+            return nestedInstance;
+
+        var adopted = FirstImageObject(resolved[adoptIndex].Value)!;
+        resolved.RemoveAt(adoptIndex);
+        return adopted;
     }
 
     /// <summary>

--- a/src/Umbraco.Community.SchemeWeaver/Services/Mapping/StructuralEnricher.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Mapping/StructuralEnricher.cs
@@ -120,7 +120,7 @@ public sealed class StructuralEnricher
                 var innerAlias = DetectSingleTextField(elements);
                 if (innerAlias is not null)
                 {
-                    suggestion.SuggestedSourceType = "blockContent";
+                    suggestion.SuggestedSourceType = SchemeWeaverConstants.SourceTypes.BlockContent;
                     suggestion.SuggestedNestedSchemaTypeName = null;
                     suggestion.SuggestedResolverConfig = SerialiseStringList(innerAlias);
                     suggestion.Confidence = Math.Max(suggestion.Confidence, _showThreshold);
@@ -130,7 +130,7 @@ public sealed class StructuralEnricher
 
             // Branch 2: block-backed nested object → supplement its nestedMappings with any extra
             // bindings discoverable by name on the block element type's own properties.
-            if (string.Equals(suggestion.SuggestedSourceType, "blockContent", StringComparison.OrdinalIgnoreCase)
+            if (string.Equals(suggestion.SuggestedSourceType, SchemeWeaverConstants.SourceTypes.BlockContent, StringComparison.OrdinalIgnoreCase)
                 && !string.IsNullOrEmpty(suggestion.SuggestedNestedSchemaTypeName))
             {
                 SupplementNestedMappings(suggestion, elements);
@@ -143,13 +143,13 @@ public sealed class StructuralEnricher
         // yields fully-populated ImageObject(s) at render time, whereas any inner bindings
         // Branch 1 could author here (ImageObject.Name <- the media alias) would drop the
         // resolved media on a string-only sub-property and emit an empty shell.
-        if (string.Equals(suggestion.SuggestedSourceType, "complexType", StringComparison.OrdinalIgnoreCase)
+        if (string.Equals(suggestion.SuggestedSourceType, SchemeWeaverConstants.SourceTypes.ComplexType, StringComparison.OrdinalIgnoreCase)
             && !string.IsNullOrEmpty(suggestion.EditorAlias)
             && MediaPickerAliases.Contains(suggestion.EditorAlias!)
             && (string.Equals(suggestion.SuggestedNestedSchemaTypeName, "ImageObject", StringComparison.OrdinalIgnoreCase)
                 || AcceptsImage(suggestion.AcceptedTypes)))
         {
-            suggestion.SuggestedSourceType = "property";
+            suggestion.SuggestedSourceType = SchemeWeaverConstants.SourceTypes.Property;
             suggestion.SuggestedNestedSchemaTypeName = null;
             suggestion.SuggestedResolverConfig = null;
             return;
@@ -158,7 +158,7 @@ public sealed class StructuralEnricher
         // Branch 1: complexType-from-scalar. A complex schema property that name-matched a scalar
         // content property but carries no inner config is dead at runtime — fill its
         // complexTypeMappings by prefix-grouping sibling content properties.
-        if (string.Equals(suggestion.SuggestedSourceType, "complexType", StringComparison.OrdinalIgnoreCase)
+        if (string.Equals(suggestion.SuggestedSourceType, SchemeWeaverConstants.SourceTypes.ComplexType, StringComparison.OrdinalIgnoreCase)
             && !string.IsNullOrEmpty(suggestion.SuggestedNestedSchemaTypeName)
             && !string.IsNullOrEmpty(matchedAlias)
             && !isBlockMatch
@@ -341,8 +341,7 @@ public sealed class StructuralEnricher
     }
 
     private static bool IsRichSourceType(string? sourceType) =>
-        string.Equals(sourceType, "complexType", StringComparison.OrdinalIgnoreCase)
-        || string.Equals(sourceType, "blockContent", StringComparison.OrdinalIgnoreCase);
+        SchemeWeaverConstants.SourceTypes.ResolvesToNestedThing(sourceType);
 
     // ---- Detection helpers -----------------------------------------------------------------
 
@@ -488,7 +487,7 @@ public sealed class StructuralEnricher
             complexTypeMappings = bindings.Select(b => new
             {
                 schemaProperty = b.SchemaProperty,
-                sourceType = "property",
+                sourceType = SchemeWeaverConstants.SourceTypes.Property,
                 contentTypePropertyAlias = b.ContentProperty,
             }),
         }, JsonOptions);

--- a/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Resolvers/BlockContentResolver.cs
@@ -50,75 +50,115 @@ public class BlockContentResolver : IPropertyValueResolver
 
         var resolverConfig = ParseResolverConfig(context.Mapping.ResolverConfig);
 
-        // String extraction mode: return List<string> from block items (e.g., recipeIngredient)
+        // MODE PRECEDENCE: stringList → routes → legacy. A config carrying both ExtractAs
+        // and Routes must still take the stringList path (this branch is evaluated first).
         if (resolverConfig?.ExtractAs == "stringList" && !string.IsNullOrEmpty(resolverConfig.ContentProperty))
-        {
-            var strings = new List<string>();
-            foreach (var blockContent in blockItems)
-            {
-                // Route through the per-editor resolver pipeline (when a factory is wired) so
-                // e.g. a MultiUrlPicker block property yields its URL string(s) rather than the
-                // raw model's ToString() garbage. A multi-value resolver result (List<string>)
-                // is flattened into the extracted list. Non-string resolver results are reduced
-                // to the string form the legacy ResolveElementPropertyValue path emitted: media
-                // ImageObject(s) contribute their URL(s), and scalars (Umbraco.Integer/Decimal →
-                // int/decimal, Umbraco.TrueFalse → bool, …) their invariant ToString(). Only
-                // non-image Things are dropped — they have no faithful scalar form.
-                var rawValue = ResolveBlockElementProperty(blockContent, resolverConfig.ContentProperty, context);
-                IEnumerable<string> extracted = rawValue switch
-                {
-                    string single => [single],
-                    IEnumerable<string> many => many,
-                    IImageObject image => ImageUrls([image]),
-                    IEnumerable<IImageObject> images => ImageUrls(images),
-                    Thing or IEnumerable<Thing> => [],
-                    IFormattable formattable => [formattable.ToString(null, CultureInfo.InvariantCulture)],
-                    not null => rawValue.ToString() is { Length: > 0 } stringified ? [stringified] : [],
-                    _ => []
-                };
+            return ResolveStringList(blockItems, resolverConfig, context);
 
-                foreach (var extractedValue in extracted)
-                {
-                    var s = extractedValue;
-                    if (string.IsNullOrEmpty(s))
-                        continue;
-
-                    // Honour a transform on the string-list path too (e.g. stripHtml a RichText
-                    // value pulled via extractAs:stringList). Re-check for emptiness after the
-                    // transform so a value that collapses to whitespace is dropped, not emitted blank.
-                    if (!string.IsNullOrEmpty(resolverConfig.TransformType))
-                        s = SchemaValueTransformer.Apply(s, resolverConfig.TransformType, context.HttpContextAccessor, _logger) ?? string.Empty;
-
-                    if (!string.IsNullOrEmpty(s))
-                        strings.Add(s);
-                }
-            }
-            return strings.Count > 0 ? strings : null;
-        }
-
-        // New routed form: each block ELEMENT TYPE has its own route (its own
-        // nested schema type + property mappings). A single block list referenced
-        // by several property mappings carries, on each mapping, only the routes
-        // (block element types) that feed that mapping's own target schema property.
-        // Block items whose alias has no route are skipped (debug, not warn-spammed),
-        // so a heterogeneous list emits a differently-typed Thing per element type.
-        // When routes are present the mapping-level NestedSchemaTypeName is irrelevant
-        // and its absence must NOT abort resolution.
         if (resolverConfig?.Routes is { Count: > 0 } routes)
-        {
-            // Keep each block paired with its mapped Thing so empty Things are dropped
-            // (P2.1) BEFORE ListItem position numbering (P2.3), keeping positions sequential.
-            var routed = blockItems
-                .Select(blockContent => (Block: blockContent, Thing: MapBlockViaRoute(blockContent, routes, context)))
-                .Where(x => x.Thing is not null)
-                .Select(x => (x.Block, Thing: x.Thing!))
-                .ToList();
+            return ResolveRouted(blockItems, routes, resolverConfig, context);
 
-            return BuildBlockResult(routed, resolverConfig, context);
+        return ResolveLegacy(blockItems, resolverConfig, context);
+    }
+
+    /// <summary>
+    /// String extraction mode: returns a <c>List&lt;string&gt;</c> pulled from each block item's
+    /// configured content property (e.g. recipeIngredient), or null when nothing survives.
+    /// </summary>
+    private List<string>? ResolveStringList(
+        IEnumerable<IPublishedElement> blockItems,
+        ResolverConfigModel resolverConfig,
+        PropertyResolverContext context)
+    {
+        var strings = new List<string>();
+        foreach (var blockContent in blockItems)
+        {
+            // Route through the per-editor resolver pipeline (when a factory is wired) so
+            // e.g. a MultiUrlPicker block property yields its URL string(s) rather than the
+            // raw model's ToString() garbage. A multi-value resolver result (List<string>)
+            // is flattened into the extracted list. Non-string resolver results are reduced
+            // to the string form the legacy ResolveElementPropertyValue path emitted: media
+            // ImageObject(s) contribute their URL(s), and scalars (Umbraco.Integer/Decimal →
+            // int/decimal, Umbraco.TrueFalse → bool, …) their invariant ToString(). Only
+            // non-image Things are dropped — they have no faithful scalar form.
+            var rawValue = ResolveBlockElementProperty(blockContent, resolverConfig.ContentProperty!, context);
+
+            foreach (var extractedValue in ExtractStrings(rawValue))
+                AppendTransformed(strings, extractedValue, resolverConfig.TransformType, context);
         }
 
-        // Legacy single-route form: one NestedSchemaTypeName + a flat NestedMappings
-        // list applies to every block in the list. Treated as one implicit route.
+        return strings.Count > 0 ? strings : null;
+    }
+
+    /// <summary>
+    /// Reduces a resolved block-element property value to the string(s) the legacy
+    /// <c>ResolveElementPropertyValue</c> path emitted. SWITCH-ARM ORDER IS LOAD-BEARING:
+    /// <c>Thing or IEnumerable&lt;Thing&gt; =&gt; []</c> must precede <c>IFormattable</c>, which must
+    /// precede <c>not null</c>. <see cref="IFormattable"/> formats with
+    /// <see cref="CultureInfo.InvariantCulture"/>.
+    /// </summary>
+    private static IEnumerable<string> ExtractStrings(object? rawValue) =>
+        rawValue switch
+        {
+            string single => [single],
+            IEnumerable<string> many => many,
+            IImageObject image => ImageUrls([image]),
+            IEnumerable<IImageObject> images => ImageUrls(images),
+            Thing or IEnumerable<Thing> => [],
+            IFormattable formattable => [formattable.ToString(null, CultureInfo.InvariantCulture)],
+            not null => rawValue.ToString() is { Length: > 0 } stringified ? [stringified] : [],
+            _ => []
+        };
+
+    /// <summary>
+    /// Appends one extracted string to <paramref name="target"/>, honouring an optional transform
+    /// (e.g. stripHtml a RichText value pulled via extractAs:stringList). DOUBLE emptiness check:
+    /// empty values are skipped BEFORE the transform, and a value that collapses to whitespace
+    /// AFTER the transform is dropped rather than emitted blank.
+    /// </summary>
+    private void AppendTransformed(
+        List<string> target,
+        string extractedValue,
+        string? transformType,
+        PropertyResolverContext context)
+    {
+        var s = extractedValue;
+        if (string.IsNullOrEmpty(s))
+            return;
+
+        if (!string.IsNullOrEmpty(transformType))
+            s = SchemaValueTransformer.Apply(s, transformType, context.HttpContextAccessor, _logger) ?? string.Empty;
+
+        if (!string.IsNullOrEmpty(s))
+            target.Add(s);
+    }
+
+    /// <summary>
+    /// New routed form: each block ELEMENT TYPE has its own route (its own nested schema type +
+    /// property mappings). A single block list referenced by several property mappings carries, on
+    /// each mapping, only the routes (block element types) that feed that mapping's own target
+    /// schema property. Block items whose alias has no route are skipped (debug, not warn-spammed),
+    /// so a heterogeneous list emits a differently-typed Thing per element type. When routes are
+    /// present the mapping-level NestedSchemaTypeName is irrelevant and its absence must NOT abort
+    /// resolution.
+    /// </summary>
+    private object? ResolveRouted(
+        IEnumerable<IPublishedElement> blockItems,
+        List<BlockRoute> routes,
+        ResolverConfigModel resolverConfig,
+        PropertyResolverContext context) =>
+        MapBlocks(blockItems, block => MapBlockViaRoute(block, routes, context), resolverConfig, context);
+
+    /// <summary>
+    /// Legacy single-route form: one NestedSchemaTypeName + a flat NestedMappings list applies to
+    /// every block in the list. Treated as one implicit route. Unlike the routed form, a missing
+    /// NestedSchemaTypeName warns and aborts (there is no per-block schema type to fall back to).
+    /// </summary>
+    private object? ResolveLegacy(
+        IEnumerable<IPublishedElement> blockItems,
+        ResolverConfigModel? resolverConfig,
+        PropertyResolverContext context)
+    {
         var nestedSchemaTypeName = context.Mapping.NestedSchemaTypeName;
         if (string.IsNullOrEmpty(nestedSchemaTypeName))
         {
@@ -128,14 +168,31 @@ public class BlockContentResolver : IPropertyValueResolver
             return null;
         }
 
-        var things = blockItems
-            .Select(blockContent => (Block: blockContent,
-                Thing: MapBlockToThing(blockContent, nestedSchemaTypeName, resolverConfig?.NestedMappings, context, resolverConfig?.RequiredProperties)))
+        return MapBlocks(
+            blockItems,
+            block => MapBlockToThing(block, nestedSchemaTypeName, resolverConfig?.NestedMappings, context, resolverConfig?.RequiredProperties),
+            resolverConfig,
+            context);
+    }
+
+    /// <summary>
+    /// Unified routed/legacy tail: maps each block via <paramref name="mapper"/>, keeping every block
+    /// paired with its mapped Thing so empty Things are dropped (P2.1) BEFORE ListItem position
+    /// numbering (P2.3), keeping positions sequential. Delegates to <see cref="BuildBlockResult"/>.
+    /// </summary>
+    private static object? MapBlocks(
+        IEnumerable<IPublishedElement> blockItems,
+        Func<IPublishedElement, Thing?> mapper,
+        ResolverConfigModel? config,
+        PropertyResolverContext context)
+    {
+        var mapped = blockItems
+            .Select(blockContent => (Block: blockContent, Thing: mapper(blockContent)))
             .Where(x => x.Thing is not null)
             .Select(x => (x.Block, Thing: x.Thing!))
             .ToList();
 
-        return BuildBlockResult(things, resolverConfig, context);
+        return BuildBlockResult(mapped, config, context);
     }
 
     /// <summary>
@@ -578,7 +635,7 @@ public class BlockContentResolver : IPropertyValueResolver
         var childMapping = new PropertyMapping
         {
             SchemaPropertyName = mapping.SchemaProperty!,
-            SourceType = "blockContent",
+            SourceType = SchemeWeaverConstants.SourceTypes.BlockContent,
             ContentTypePropertyAlias = nestedProperty.Alias,
             ResolverConfig = JsonSerializer.Serialize(nestedConfig)
         };
@@ -864,7 +921,7 @@ public class ComplexTypeConfigModel
 public class ComplexTypeMappingEntry
 {
     public string SchemaProperty { get; set; } = string.Empty;
-    public string SourceType { get; set; } = "property";   // "property", "static", or "complexType"
+    public string SourceType { get; set; } = SchemeWeaverConstants.SourceTypes.Property;   // "property", "static", or "complexType"
     public string? ContentTypePropertyAlias { get; set; }
     public string? StaticValue { get; set; }
     public string? SourceContentTypeAlias { get; set; }

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaAutoMapper.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaAutoMapper.cs
@@ -404,190 +404,37 @@ public class SchemaAutoMapper : ISchemaAutoMapper
             {
                 SchemaPropertyName = schemaProp.Name,
                 SchemaPropertyType = schemaProp.PropertyType,
-                SuggestedSourceType = "property",
+                SuggestedSourceType = SchemeWeaverConstants.SourceTypes.Property,
                 AcceptedTypes = schemaProp.AcceptedTypes,
                 IsComplexType = schemaProp.IsComplexType,
             };
 
-            // Check for popular schema defaults first
+            // Popular schema defaults are consulted both by the matched tiers (via
+            // ApplyComplexTypeInference) and by the no-match ladder in ResolveUnmatched.
             var defaultKey = $"{schemaTypeName}.{schemaProp.Name}";
             var hasPopularDefault = PopularSchemaDefaults.TryGetValue(defaultKey, out var popularDefault);
+            Synonyms.TryGetValue(schemaProp.Name, out var synonyms);
 
-            // Exact match (case-insensitive)
-            var exactMatch = contentProperties.FirstOrDefault(
-                p => string.Equals(p.Alias, schemaProp.Name, StringComparison.OrdinalIgnoreCase));
+            // Tier precedence: exact → synonym → partial → built-in, FIRST match wins.
+            // Exact/synonym/partial share one populate-and-return helper, differing only in
+            // their base confidence and candidate matcher; `||` short-circuits so the first
+            // tier that matches-and-populates stops the ladder (as the old `continue`s did).
+            var matched =
+                TryMatchTier(suggestion, schemaProp, contentProperties, 100,
+                    p => string.Equals(p.Alias, schemaProp.Name, StringComparison.OrdinalIgnoreCase),
+                    hasPopularDefault, popularDefault)
+                || TryMatchTier(suggestion, schemaProp, contentProperties, 80,
+                    p => synonyms is not null
+                        && synonyms.Any(s => string.Equals(p.Alias, s, StringComparison.OrdinalIgnoreCase)),
+                    hasPopularDefault, popularDefault)
+                || TryMatchTier(suggestion, schemaProp, contentProperties, 50,
+                    p => p.Alias.Contains(schemaProp.Name, StringComparison.OrdinalIgnoreCase)
+                        || schemaProp.Name.Contains(p.Alias, StringComparison.OrdinalIgnoreCase),
+                    hasPopularDefault, popularDefault)
+                || TryBuiltIn(suggestion, schemaProp);
 
-            if (exactMatch is not null)
-            {
-                suggestion.SuggestedContentTypePropertyAlias = exactMatch.Alias;
-                suggestion.EditorAlias = exactMatch.PropertyEditorAlias;
-                suggestion.Confidence = BoostForEditorMatch(100, exactMatch.PropertyEditorAlias, schemaProp);
-                suggestion.IsAutoMapped = true;
-
-                ApplyComplexTypeInference(suggestion, exactMatch.PropertyEditorAlias, hasPopularDefault, popularDefault);
-                suggestions.Add(suggestion);
-                continue;
-            }
-
-            // Synonym match
-            if (Synonyms.TryGetValue(schemaProp.Name, out var synonyms))
-            {
-                var synonymMatch = contentProperties.FirstOrDefault(
-                    p => synonyms.Any(s => string.Equals(p.Alias, s, StringComparison.OrdinalIgnoreCase)));
-
-                if (synonymMatch is not null)
-                {
-                    suggestion.SuggestedContentTypePropertyAlias = synonymMatch.Alias;
-                    suggestion.EditorAlias = synonymMatch.PropertyEditorAlias;
-                    suggestion.Confidence = BoostForEditorMatch(80, synonymMatch.PropertyEditorAlias, schemaProp);
-                    suggestion.IsAutoMapped = true;
-
-                    ApplyComplexTypeInference(suggestion, synonymMatch.PropertyEditorAlias, hasPopularDefault, popularDefault);
-                    suggestions.Add(suggestion);
-                    continue;
-                }
-            }
-
-            // Partial match (schema property name contained in content property alias or vice versa)
-            var partialMatch = contentProperties.FirstOrDefault(
-                p => p.Alias.Contains(schemaProp.Name, StringComparison.OrdinalIgnoreCase)
-                  || schemaProp.Name.Contains(p.Alias, StringComparison.OrdinalIgnoreCase));
-
-            if (partialMatch is not null)
-            {
-                suggestion.SuggestedContentTypePropertyAlias = partialMatch.Alias;
-                suggestion.EditorAlias = partialMatch.PropertyEditorAlias;
-                suggestion.Confidence = BoostForEditorMatch(50, partialMatch.PropertyEditorAlias, schemaProp);
-                suggestion.IsAutoMapped = true;
-
-                ApplyComplexTypeInference(suggestion, partialMatch.PropertyEditorAlias, hasPopularDefault, popularDefault);
-                suggestions.Add(suggestion);
-                continue;
-            }
-
-            // Built-in property auto-mapping (URL, Name, dates) as fallback when no custom property matched
-            if (!schemaProp.IsComplexType)
-            {
-                var builtInAlias = TryMatchBuiltInProperty(schemaProp);
-                if (builtInAlias is not null)
-                {
-                    suggestion.SuggestedContentTypePropertyAlias = builtInAlias;
-                    suggestion.EditorAlias = SchemeWeaverConstants.BuiltInProperties.EditorAlias;
-                    // Canonical built-in mappings (schema url → node url, name → node Name,
-                    // datePublished → CreateDate, dateModified → UpdateDate). Scored at the
-                    // auto-apply bar so they stay pre-ticked after the confidence filter.
-                    suggestion.Confidence = 80;
-                    suggestion.IsAutoMapped = true;
-                    suggestions.Add(suggestion);
-                    continue;
-                }
-            }
-
-            // No content property match — check for complex type defaults. A "property"-
-            // sourced popular default (e.g. *.logo) needs a real content property to bind;
-            // with no match it would author a dead alias-less row, so fall through to the
-            // generic complexType handling instead.
-            if (schemaProp.IsComplexType && hasPopularDefault
-                && !string.Equals(popularDefault!.SourceType, "property", StringComparison.OrdinalIgnoreCase))
-            {
-                suggestion.SuggestedSourceType = popularDefault!.SourceType;
-                suggestion.SuggestedNestedSchemaTypeName = popularDefault.NestedSchemaTypeName;
-                suggestion.SuggestedResolverConfig = popularDefault.ResolverConfig;
-                suggestion.SuggestedTargetPieceKey = popularDefault.TargetPieceKey;
-
-                // Reference-typed popular defaults (e.g. AboutPage.about → org
-                // piece) don't need a block property on the content type — they
-                // resolve at graph-generation time from registered pieces.
-                if (popularDefault.SourceType == "reference")
-                {
-                    suggestion.Confidence = 90;
-                    suggestion.IsAutoMapped = true;
-                }
-                // For blockContent defaults, only auto-map if a matching block property exists
-                else if (popularDefault.SourceType == "blockContent")
-                {
-                    var blockProperty = contentProperties
-                        .FirstOrDefault(p => BlockEditorAliases.Contains(p.PropertyEditorAlias));
-                    if (blockProperty is not null)
-                    {
-                        suggestion.SuggestedContentTypePropertyAlias = blockProperty.Alias;
-                        suggestion.EditorAlias = blockProperty.PropertyEditorAlias;
-                        suggestion.Confidence = 60;
-                        suggestion.IsAutoMapped = true;
-                    }
-                    else
-                    {
-                        suggestion.Confidence = 0;
-                        suggestion.IsAutoMapped = false;
-                    }
-                }
-                else
-                {
-                    suggestion.Confidence = 60;
-                    suggestion.IsAutoMapped = true;
-                }
-            }
-            else if (schemaProp.IsComplexType)
-            {
-                var nestedType = GetFirstNonPrimitiveAcceptedType(schemaProp.AcceptedTypes);
-                if (nestedType is not null)
-                {
-                    // Has a real complex type — if it's a known cross-piece ref
-                    // candidate (about, publisher, worksFor, isPartOf, …), suggest
-                    // `reference` so the user gets a one-click Yoast-style @id ref.
-                    if (ReferenceCandidates.TryGetValue(schemaProp.Name, out var targetPieceKey))
-                    {
-                        suggestion.SuggestedSourceType = "reference";
-                        suggestion.SuggestedTargetPieceKey = targetPieceKey;
-                        suggestion.Confidence = 70;
-                        suggestion.IsAutoMapped = true;
-                    }
-                    // Else: generic target-type fallback. If the content type has
-                    // a BlockList/BlockGrid property we can plausibly map to a
-                    // collection of the nested type, suggest that at low confidence
-                    // so the user sees an actionable starting point instead of
-                    // an empty slot.
-                    else if (IsArrayProperty(schemaProp)
-                        && contentProperties.FirstOrDefault(p => BlockEditorAliases.Contains(p.PropertyEditorAlias)) is { } blockProp)
-                    {
-                        suggestion.SuggestedSourceType = "blockContent";
-                        suggestion.SuggestedNestedSchemaTypeName = nestedType;
-                        suggestion.SuggestedContentTypePropertyAlias = blockProp.Alias;
-                        suggestion.EditorAlias = blockProp.PropertyEditorAlias;
-                        suggestion.Confidence = 40;
-                        suggestion.IsAutoMapped = true;
-                    }
-                    else
-                    {
-                        suggestion.SuggestedSourceType = "complexType";
-                        suggestion.SuggestedNestedSchemaTypeName = nestedType;
-                        suggestion.Confidence = 0;
-                        suggestion.IsAutoMapped = false;
-                    }
-                }
-                else
-                {
-                    // All accepted types are primitive (e.g. String) — treat as simple unmatched
-                    suggestion.IsComplexType = false;
-                    suggestion.Confidence = 0;
-                    suggestion.IsAutoMapped = false;
-                }
-            }
-            else if (ReferenceCandidates.TryGetValue(schemaProp.Name, out var targetPieceKey2))
-            {
-                // Non-complex property with a known cross-piece ref name — rare
-                // but handles e.g. future primitive refs. Low confidence because
-                // we're guessing from name alone.
-                suggestion.SuggestedSourceType = "reference";
-                suggestion.SuggestedTargetPieceKey = targetPieceKey2;
-                suggestion.Confidence = 50;
-                suggestion.IsAutoMapped = true;
-            }
-            else
-            {
-                suggestion.Confidence = 0;
-                suggestion.IsAutoMapped = false;
-            }
+            if (!matched)
+                ResolveUnmatched(suggestion, schemaProp, contentProperties, hasPopularDefault, popularDefault);
 
             suggestions.Add(suggestion);
         }
@@ -624,6 +471,197 @@ public class SchemaAutoMapper : ISchemaAutoMapper
         return suggestions
             .Where(s => s.Confidence >= _showThreshold)
             .ToList();
+    }
+
+    /// <summary>
+    /// Populate-and-return for the exact / synonym / partial name-match tiers, which are identical
+    /// apart from their base confidence and candidate matcher. On a match it fills the suggestion
+    /// (alias, editor, editor-boosted confidence, auto-mapped) and runs <see cref="ApplyComplexTypeInference"/>
+    /// exactly as the flat tiers did, then returns true; returns false (leaving the suggestion untouched)
+    /// when no candidate matches so the caller can try the next tier.
+    /// </summary>
+    private static bool TryMatchTier(
+        PropertyMappingSuggestion suggestion,
+        SchemaPropertyInfo schemaProp,
+        List<IPropertyType> contentProperties,
+        int baseConfidence,
+        Func<IPropertyType, bool> matcher,
+        bool hasPopularDefault,
+        PopularSchemaDefault? popularDefault)
+    {
+        var match = contentProperties.FirstOrDefault(matcher);
+        if (match is null)
+            return false;
+
+        suggestion.SuggestedContentTypePropertyAlias = match.Alias;
+        suggestion.EditorAlias = match.PropertyEditorAlias;
+        suggestion.Confidence = BoostForEditorMatch(baseConfidence, match.PropertyEditorAlias, schemaProp);
+        suggestion.IsAutoMapped = true;
+
+        ApplyComplexTypeInference(suggestion, match.PropertyEditorAlias, hasPopularDefault, popularDefault);
+        return true;
+    }
+
+    /// <summary>
+    /// Built-in property auto-mapping (URL, Name, dates) used as a fallback when no custom property
+    /// matched. Only applies to non-complex schema properties. Canonical built-in mappings
+    /// (schema url → node url, name → node Name, datePublished → CreateDate, dateModified → UpdateDate)
+    /// are scored at the auto-apply bar so they stay pre-ticked after the confidence filter.
+    /// </summary>
+    private static bool TryBuiltIn(PropertyMappingSuggestion suggestion, SchemaPropertyInfo schemaProp)
+    {
+        if (schemaProp.IsComplexType)
+            return false;
+
+        var builtInAlias = TryMatchBuiltInProperty(schemaProp);
+        if (builtInAlias is null)
+            return false;
+
+        suggestion.SuggestedContentTypePropertyAlias = builtInAlias;
+        suggestion.EditorAlias = SchemeWeaverConstants.BuiltInProperties.EditorAlias;
+        suggestion.Confidence = 80;
+        suggestion.IsAutoMapped = true;
+        return true;
+    }
+
+    /// <summary>
+    /// No content property matched: resolves the suggestion from popular defaults, reference
+    /// candidates and complex-type fallbacks. A <c>property</c>-sourced popular default (e.g. *.logo)
+    /// is EXCLUDED here — it needs a real content property to bind, so with no match it falls through
+    /// to the generic complex handling instead of authoring a dead alias-less row (mirrors
+    /// <see cref="ApplyComplexTypeInference"/>).
+    /// </summary>
+    private static void ResolveUnmatched(
+        PropertyMappingSuggestion suggestion,
+        SchemaPropertyInfo schemaProp,
+        List<IPropertyType> contentProperties,
+        bool hasPopularDefault,
+        PopularSchemaDefault? popularDefault)
+    {
+        if (schemaProp.IsComplexType && hasPopularDefault
+            && !string.Equals(popularDefault!.SourceType, SchemeWeaverConstants.SourceTypes.Property, StringComparison.OrdinalIgnoreCase))
+        {
+            ApplyPopularDefaultForUnmatched(suggestion, contentProperties, popularDefault!);
+            return;
+        }
+
+        if (schemaProp.IsComplexType)
+        {
+            ResolveUnmatchedComplex(suggestion, schemaProp, contentProperties);
+            return;
+        }
+
+        if (ReferenceCandidates.TryGetValue(schemaProp.Name, out var targetPieceKey))
+        {
+            // Non-complex property with a known cross-piece ref name — rare but handles e.g. future
+            // primitive refs. Low confidence because we're guessing from name alone.
+            suggestion.SuggestedSourceType = SchemeWeaverConstants.SourceTypes.Reference;
+            suggestion.SuggestedTargetPieceKey = targetPieceKey;
+            suggestion.Confidence = 50;
+            suggestion.IsAutoMapped = true;
+            return;
+        }
+
+        suggestion.Confidence = 0;
+        suggestion.IsAutoMapped = false;
+    }
+
+    /// <summary>
+    /// Applies a non-<c>property</c> popular default to an unmatched complex suggestion. Reference
+    /// defaults (e.g. AboutPage.about → org piece) resolve at graph-generation time and need no block
+    /// property; blockContent defaults only auto-map when a matching block property exists; everything
+    /// else is a shown-but-not-auto-applied complexType default.
+    /// </summary>
+    private static void ApplyPopularDefaultForUnmatched(
+        PropertyMappingSuggestion suggestion,
+        List<IPropertyType> contentProperties,
+        PopularSchemaDefault popularDefault)
+    {
+        suggestion.SuggestedSourceType = popularDefault.SourceType;
+        suggestion.SuggestedNestedSchemaTypeName = popularDefault.NestedSchemaTypeName;
+        suggestion.SuggestedResolverConfig = popularDefault.ResolverConfig;
+        suggestion.SuggestedTargetPieceKey = popularDefault.TargetPieceKey;
+
+        // Case-sensitive switch (matches the render path's `==` comparison policy for source types).
+        switch (popularDefault.SourceType)
+        {
+            case SchemeWeaverConstants.SourceTypes.Reference:
+                suggestion.Confidence = 90;
+                suggestion.IsAutoMapped = true;
+                break;
+
+            case SchemeWeaverConstants.SourceTypes.BlockContent:
+            {
+                var blockProperty = contentProperties
+                    .FirstOrDefault(p => BlockEditorAliases.Contains(p.PropertyEditorAlias));
+                if (blockProperty is not null)
+                {
+                    suggestion.SuggestedContentTypePropertyAlias = blockProperty.Alias;
+                    suggestion.EditorAlias = blockProperty.PropertyEditorAlias;
+                    suggestion.Confidence = 60;
+                    suggestion.IsAutoMapped = true;
+                }
+                else
+                {
+                    suggestion.Confidence = 0;
+                    suggestion.IsAutoMapped = false;
+                }
+                break;
+            }
+
+            default:
+                suggestion.Confidence = 60;
+                suggestion.IsAutoMapped = true;
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Unmatched complex property with no usable popular default. A known cross-piece ref name
+    /// (about, publisher, worksFor, isPartOf, …) becomes a one-click <c>reference</c> @id ref; an
+    /// array property with a Block List/Grid present becomes a low-confidence blockContent guess; a
+    /// primitive-only accepted-types set collapses to a simple unmatched row; otherwise it is a
+    /// shown-but-not-applied complexType placeholder.
+    /// </summary>
+    private static void ResolveUnmatchedComplex(
+        PropertyMappingSuggestion suggestion,
+        SchemaPropertyInfo schemaProp,
+        List<IPropertyType> contentProperties)
+    {
+        var nestedType = GetFirstNonPrimitiveAcceptedType(schemaProp.AcceptedTypes);
+        if (nestedType is null)
+        {
+            // All accepted types are primitive (e.g. String) — treat as simple unmatched.
+            suggestion.IsComplexType = false;
+            suggestion.Confidence = 0;
+            suggestion.IsAutoMapped = false;
+            return;
+        }
+
+        if (ReferenceCandidates.TryGetValue(schemaProp.Name, out var targetPieceKey))
+        {
+            suggestion.SuggestedSourceType = SchemeWeaverConstants.SourceTypes.Reference;
+            suggestion.SuggestedTargetPieceKey = targetPieceKey;
+            suggestion.Confidence = 70;
+            suggestion.IsAutoMapped = true;
+        }
+        else if (IsArrayProperty(schemaProp)
+            && contentProperties.FirstOrDefault(p => BlockEditorAliases.Contains(p.PropertyEditorAlias)) is { } blockProp)
+        {
+            suggestion.SuggestedSourceType = SchemeWeaverConstants.SourceTypes.BlockContent;
+            suggestion.SuggestedNestedSchemaTypeName = nestedType;
+            suggestion.SuggestedContentTypePropertyAlias = blockProp.Alias;
+            suggestion.EditorAlias = blockProp.PropertyEditorAlias;
+            suggestion.Confidence = 40;
+            suggestion.IsAutoMapped = true;
+        }
+        else
+        {
+            suggestion.SuggestedSourceType = SchemeWeaverConstants.SourceTypes.ComplexType;
+            suggestion.SuggestedNestedSchemaTypeName = nestedType;
+            suggestion.Confidence = 0;
+            suggestion.IsAutoMapped = false;
+        }
     }
 
     public IEnumerable<RankedSchemaPropertyInfo> RankSchemaProperties(string schemaTypeName)
@@ -748,50 +786,60 @@ public class SchemaAutoMapper : ISchemaAutoMapper
         if (baseConfidence >= 100 || string.IsNullOrEmpty(editorAlias))
             return baseConfidence;
 
-        var editor = editorAlias;
         var accepted = schemaProp.AcceptedTypes ?? [];
         var propertyType = schemaProp.PropertyType ?? string.Empty;
 
-        var boosted = false;
-
-        // MediaPicker → image-shaped schema properties (ImageObject, MediaObject,
-        // ImageObject-accepting Thing fields like logo / image / photo).
-        if (editor.Contains("MediaPicker", StringComparison.OrdinalIgnoreCase)
-            && (AcceptsAny(accepted, "ImageObject", "MediaObject")
-                || propertyType.Contains("ImageObject", StringComparison.OrdinalIgnoreCase)))
-        {
-            boosted = true;
-        }
-
-        // DateTime picker → Date-family schema properties (DateTime, Date, Time).
-        else if (editor.Equals("Umbraco.DateTime", StringComparison.OrdinalIgnoreCase)
-            && (propertyType.Contains("DateTime", StringComparison.OrdinalIgnoreCase)
-                || propertyType.Contains("Date", StringComparison.OrdinalIgnoreCase)
-                || propertyType.Contains("Time", StringComparison.OrdinalIgnoreCase)
-                || AcceptsAny(accepted, "DateTime", "Date", "Time")))
-        {
-            boosted = true;
-        }
-
-        // MultiUrlPicker → URL-shaped properties (SameAs arrays, primary URL fields).
-        else if (editor.Equals("Umbraco.MultiUrlPicker", StringComparison.OrdinalIgnoreCase)
-            && (propertyType.Contains("URL", StringComparison.OrdinalIgnoreCase)
-                || AcceptsAny(accepted, "URL")))
-        {
-            boosted = true;
-        }
-
-        // Tags / MultipleTextstring → text-array properties (keywords, sameAs).
-        else if ((editor.Equals("Umbraco.Tags", StringComparison.OrdinalIgnoreCase)
-                || editor.Equals("Umbraco.MultipleTextstring", StringComparison.OrdinalIgnoreCase))
-            && (propertyType.Contains("Text", StringComparison.OrdinalIgnoreCase)
-                || AcceptsAny(accepted, "Text")))
-        {
-            boosted = true;
-        }
+        // The rules are mutually exclusive by editor family, and the boost is a flat +15 (never
+        // cumulative), so evaluating them as `Any` is equivalent to the old if/else-if chain.
+        var boosted = EditorBoostRules.Any(r => r.EditorMatches(editorAlias) && r.TargetMatches(accepted, propertyType));
 
         return boosted ? Math.Min(100, baseConfidence + 15) : baseConfidence;
     }
+
+    /// <summary>
+    /// A single editor↔target-shape alignment rule for <see cref="BoostForEditorMatch"/>.
+    /// <paramref name="EditorMatches"/> tests the Umbraco editor alias; <paramref name="TargetMatches"/>
+    /// tests the Schema.org target (accepted types + property type). Both are OrdinalIgnoreCase.
+    /// </summary>
+    private sealed record EditorBoostRule(
+        Func<string, bool> EditorMatches,
+        Func<List<string>, string, bool> TargetMatches);
+
+    /// <summary>
+    /// Editor-alias → target-shape boost rules. Each matched rule adds a flat +15 (capped at 100 by
+    /// the caller). MediaPicker uses substring <c>Contains</c>; the others match the editor alias
+    /// exactly with <c>Equals</c>. Order is irrelevant — the caller uses <c>Any</c>.
+    /// </summary>
+    private static readonly EditorBoostRule[] EditorBoostRules =
+    [
+        // MediaPicker → image-shaped schema properties (ImageObject, MediaObject,
+        // ImageObject-accepting Thing fields like logo / image / photo).
+        new(
+            editor => editor.Contains("MediaPicker", StringComparison.OrdinalIgnoreCase),
+            (accepted, propertyType) => AcceptsAny(accepted, "ImageObject", "MediaObject")
+                || propertyType.Contains("ImageObject", StringComparison.OrdinalIgnoreCase)),
+
+        // DateTime picker → Date-family schema properties (DateTime, Date, Time).
+        new(
+            editor => editor.Equals("Umbraco.DateTime", StringComparison.OrdinalIgnoreCase),
+            (accepted, propertyType) => propertyType.Contains("DateTime", StringComparison.OrdinalIgnoreCase)
+                || propertyType.Contains("Date", StringComparison.OrdinalIgnoreCase)
+                || propertyType.Contains("Time", StringComparison.OrdinalIgnoreCase)
+                || AcceptsAny(accepted, "DateTime", "Date", "Time")),
+
+        // MultiUrlPicker → URL-shaped properties (SameAs arrays, primary URL fields).
+        new(
+            editor => editor.Equals("Umbraco.MultiUrlPicker", StringComparison.OrdinalIgnoreCase),
+            (accepted, propertyType) => propertyType.Contains("URL", StringComparison.OrdinalIgnoreCase)
+                || AcceptsAny(accepted, "URL")),
+
+        // Tags / MultipleTextstring → text-array properties (keywords, sameAs).
+        new(
+            editor => editor.Equals("Umbraco.Tags", StringComparison.OrdinalIgnoreCase)
+                || editor.Equals("Umbraco.MultipleTextstring", StringComparison.OrdinalIgnoreCase),
+            (accepted, propertyType) => propertyType.Contains("Text", StringComparison.OrdinalIgnoreCase)
+                || AcceptsAny(accepted, "Text")),
+    ];
 
     /// <summary>
     /// Heuristic: does the Schema.org property type look like it holds an array

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemaPropertySetter.cs
@@ -35,93 +35,13 @@ public static class SchemaPropertySetter
 
         var targetType = property.PropertyType;
 
-        // If the value is already the correct type, set directly
-        if (targetType.IsInstanceOfType(value))
+        // Try each conversion strategy in declared order; the first that handles the value wins.
+        // The order is load-bearing (identity first, image→Uri range guard before any coercion,
+        // whole-collection before first-string fallback) — see the SetStrategies table.
+        foreach (var strategy in SetStrategies)
         {
-            property.SetValue(instance, value);
-            return;
-        }
-
-        // Media values now arrive as Schema.NET ImageObject(s). When the target accepts
-        // IImageObject (e.g. Article.Image, Organization.Logo) we fall through to the normal
-        // OneOrMany/Values/collection handling below, which sets the ImageObject(s) directly.
-        // But some targets accept only a Uri leaf (e.g. Thing.Url, contentUrl, sameAs) and NOT
-        // IImageObject — an ImageObject would otherwise be dropped. Downgrade it to its URL.
-        if (IsImageObjectValue(value)
-            && !TargetAcceptsLeaf(targetType, typeof(IImageObject))
-            && TargetAcceptsLeaf(targetType, typeof(Uri)))
-        {
-            var downgraded = DowngradeImageToUri(value);
-            if (downgraded is not null)
-            {
-                SetPropertyValue(instance, propertyName, downgraded, logger);
+            if (strategy(property, instance, propertyName, targetType, value, logger))
                 return;
-            }
-        }
-
-        // Try to find an implicit conversion operator that accepts our value type
-        var converted = TryConvertViaImplicit(targetType, value);
-        if (converted is not null)
-        {
-            property.SetValue(instance, converted);
-            return;
-        }
-
-        // Handle IEnumerable<Thing> for collection properties (e.g., block content results)
-        if (value is IEnumerable<Thing> things
-            && TrySetCollectionValue(property, instance, targetType, things))
-            return;
-
-        // Handle IEnumerable<string> for string array properties (e.g., recipeIngredient)
-        if (value is IEnumerable<string> strings)
-        {
-            if (TrySetStringCollectionValue(property, instance, targetType, strings))
-                return;
-
-            // The collection could not be set as a whole (e.g. a bare Values<...> target).
-            // Fall back to the FIRST string so a multi-value resolver result (e.g. a
-            // MultiUrlPicker with several links) never regresses a target that previously
-            // accepted a single string value.
-            var firstString = strings.FirstOrDefault(s => !string.IsNullOrEmpty(s));
-            if (firstString is not null)
-            {
-                SetPropertyValue(instance, propertyName, firstString, logger);
-                return;
-            }
-        }
-
-        // Handle OneOrMany<T> types from Schema.NET by building from inside out
-        if (targetType is { IsGenericType: true } && targetType.GetGenericTypeDefinition().Name.StartsWith("OneOrMany")
-            && TrySetOneOrManyValue(property, instance, targetType, value))
-            return;
-
-        // Handle Values<T1, T2, ...> types directly (e.g., Image is Values<IImageObject, Uri>)
-        if (targetType is { IsGenericType: true } && targetType.GetGenericTypeDefinition().Name.StartsWith("Values")
-            && TrySetValuesValue(property, instance, targetType, value))
-            return;
-
-        // Simple string assignment
-        if (targetType == typeof(string) && value is string strVal)
-        {
-            property.SetValue(instance, strVal);
-            return;
-        }
-
-        // Auto-wrap scalar strings into a concrete Thing for object-typed properties.
-        // e.g. `Brand` mapped from a Textbox → { "@type": "Brand", "name": "AudioTech" }.
-        // Users very commonly map Schema.org object properties (Brand, Author, Publisher)
-        // from a plain string field; without this fallback Schema.NET silently drops the
-        // value because no implicit conversion from string to IBrand/IPerson exists.
-        if (value is string scalarString && !string.IsNullOrWhiteSpace(scalarString))
-        {
-            var wrapped = TryWrapScalarAsThing(targetType, propertyName, scalarString);
-            if (wrapped is not null)
-            {
-                // Re-enter the main setter with the wrapped Thing — it will match the
-                // normal Thing-handling paths (implicit conversion / OneOrMany / Values).
-                SetPropertyValue(instance, propertyName, wrapped, logger);
-                return;
-            }
         }
 
         // Nothing matched: the value's type can't be converted to the target
@@ -133,6 +53,147 @@ public static class SchemaPropertySetter
             "Could not set Schema property '{PropertyName}' on {SchemaType}: value of type {ValueType} " +
             "is not convertible to the property's type {TargetType} and was dropped",
             propertyName, instance.GetType().Name, value.GetType().Name, targetType.Name);
+    }
+
+    /// <summary>
+    /// One conversion strategy in the <see cref="SetPropertyValue"/> chain. Returns <c>true</c>
+    /// when it has set the property (the chain then stops), <c>false</c> to defer to the next
+    /// strategy. Strategies never throw on a bad match — they simply return <c>false</c>.
+    /// </summary>
+    private delegate bool SetStrategy(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger);
+
+    /// <summary>
+    /// The ordered conversion chain for <see cref="SetPropertyValue"/>. ORDER IS BEHAVIOURAL:
+    /// the fast identity path runs first; the ImageObject→Uri range guard runs before any
+    /// coercion; the whole-string-collection set runs before the first-string fallback.
+    /// </summary>
+    private static readonly SetStrategy[] SetStrategies =
+    [
+        TrySetAssignableIdentity,   // 1. value already the correct type — set directly
+        TryDowngradeImageToUriLeaf, // 2. image→Uri range guard (REV-1)
+        TrySetImplicit,             // 3. implicit conversion operator
+        TrySetThingEnumerable,      // 4. IEnumerable<Thing> collection
+        TrySetStringEnumerable,     // 5. IEnumerable<string> collection (+ first-string fallback)
+        TrySetOneOrMany,            // 6. OneOrMany<T>
+        TrySetValues,               // 7. Values<T1, T2, ...>
+        TrySetStringAssignment,     // 8. plain string assignment
+        TryWrapScalarThing,         // 9. scalar string → concrete Thing auto-wrap
+    ];
+
+    // If the value is already the correct type, set directly.
+    private static bool TrySetAssignableIdentity(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+    {
+        if (!targetType.IsInstanceOfType(value))
+            return false;
+
+        property.SetValue(instance, value);
+        return true;
+    }
+
+    // Media values now arrive as Schema.NET ImageObject(s). When the target accepts
+    // IImageObject (e.g. Article.Image, Organization.Logo) we fall through to the normal
+    // OneOrMany/Values/collection handling below, which sets the ImageObject(s) directly.
+    // But some targets accept only a Uri leaf (e.g. Thing.Url, contentUrl, sameAs) and NOT
+    // IImageObject — an ImageObject would otherwise be dropped. Downgrade it to its URL.
+    private static bool TryDowngradeImageToUriLeaf(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+    {
+        if (IsImageObjectValue(value)
+            && !TargetAcceptsLeaf(targetType, typeof(IImageObject))
+            && TargetAcceptsLeaf(targetType, typeof(Uri)))
+        {
+            var downgraded = DowngradeImageToUri(value);
+            if (downgraded is not null)
+            {
+                SetPropertyValue(instance, propertyName, downgraded, logger);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Try to find an implicit conversion operator that accepts our value type.
+    private static bool TrySetImplicit(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+        => TrySetViaImplicit(property, instance, targetType, value);
+
+    // Handle IEnumerable<Thing> for collection properties (e.g., block content results).
+    private static bool TrySetThingEnumerable(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+        => value is IEnumerable<Thing> things
+           && TrySetCollectionValue(property, instance, targetType, things);
+
+    // Handle IEnumerable<string> for string array properties (e.g., recipeIngredient).
+    private static bool TrySetStringEnumerable(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+    {
+        if (value is not IEnumerable<string> strings)
+            return false;
+
+        if (TrySetStringCollectionValue(property, instance, targetType, strings))
+            return true;
+
+        // The collection could not be set as a whole (e.g. a bare Values<...> target).
+        // Fall back to the FIRST string so a multi-value resolver result (e.g. a
+        // MultiUrlPicker with several links) never regresses a target that previously
+        // accepted a single string value.
+        var firstString = strings.FirstOrDefault(s => !string.IsNullOrEmpty(s));
+        if (firstString is not null)
+        {
+            SetPropertyValue(instance, propertyName, firstString, logger);
+            return true;
+        }
+
+        return false;
+    }
+
+    // Handle OneOrMany<T> types from Schema.NET by building from inside out.
+    private static bool TrySetOneOrMany(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+        => targetType is { IsGenericType: true }
+           && targetType.GetGenericTypeDefinition().Name.StartsWith("OneOrMany")
+           && TrySetOneOrManyValue(property, instance, targetType, value);
+
+    // Handle Values<T1, T2, ...> types directly (e.g., Image is Values<IImageObject, Uri>).
+    private static bool TrySetValues(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+        => targetType is { IsGenericType: true }
+           && targetType.GetGenericTypeDefinition().Name.StartsWith("Values")
+           && TrySetValuesValue(property, instance, targetType, value);
+
+    // Simple string assignment.
+    private static bool TrySetStringAssignment(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+    {
+        if (targetType != typeof(string) || value is not string strVal)
+            return false;
+
+        property.SetValue(instance, strVal);
+        return true;
+    }
+
+    // Auto-wrap scalar strings into a concrete Thing for object-typed properties.
+    // e.g. `Brand` mapped from a Textbox → { "@type": "Brand", "name": "AudioTech" }.
+    // Users very commonly map Schema.org object properties (Brand, Author, Publisher)
+    // from a plain string field; without this fallback Schema.NET silently drops the
+    // value because no implicit conversion from string to IBrand/IPerson exists.
+    private static bool TryWrapScalarThing(
+        PropertyInfo property, Thing instance, string propertyName, Type targetType, object value, ILogger? logger)
+    {
+        if (value is not string scalarString || string.IsNullOrWhiteSpace(scalarString))
+            return false;
+
+        var wrapped = TryWrapScalarAsThing(targetType, propertyName, scalarString);
+        if (wrapped is null)
+            return false;
+
+        // Re-enter the main setter with the wrapped Thing — it will match the
+        // normal Thing-handling paths (implicit conversion / OneOrMany / Values).
+        SetPropertyValue(instance, propertyName, wrapped, logger);
+        return true;
     }
 
     /// <summary>
@@ -476,20 +537,7 @@ public static class SchemaPropertySetter
         }
 
         // Fallback: try Activator
-        try
-        {
-            var oneOrMany = Activator.CreateInstance(targetType, typedList);
-            property.SetValue(instance, oneOrMany);
-            return true;
-        }
-        catch (MissingMethodException)
-        {
-            return false;
-        }
-        catch (TargetInvocationException)
-        {
-            return false;
-        }
+        return TryConstructAndSet(property, instance, targetType, typedList);
     }
 
     /// <summary>
@@ -534,20 +582,7 @@ public static class SchemaPropertySetter
                 list.Add(itemConverted);
         }
 
-        try
-        {
-            var oneOrManyInstance = Activator.CreateInstance(targetType, list);
-            property.SetValue(instance, oneOrManyInstance);
-            return true;
-        }
-        catch (MissingMethodException)
-        {
-            return false;
-        }
-        catch (TargetInvocationException)
-        {
-            return false;
-        }
+        return TryConstructAndSet(property, instance, targetType, list);
     }
 
     /// <summary>
@@ -558,90 +593,113 @@ public static class SchemaPropertySetter
     {
         var innerType = targetType.GetGenericArguments()[0];
 
-        // Handle OneOrMany<Values<T1,T2,...>> — the most common Schema.NET pattern
+        // Handle OneOrMany<Values<T1,T2,...>> — the most common Schema.NET pattern.
+        // Build the inner Values<> (implicit + string coercions), then wrap it in OneOrMany<>
+        // via implicit-operator-then-constructor. When both wrapping paths fail we fall through
+        // to the simpler OneOrMany<T> / general handling below.
         if (innerType is { IsGenericType: true } && innerType.GetGenericTypeDefinition().Name.StartsWith("Values"))
         {
             var valuesArgs = innerType.GetGenericArguments();
-
-            // Build Values<> via implicit operator
-            object? valuesInstance = TryConvertViaImplicit(innerType, value);
-
-            // If value is a string, try string-specific conversions
-            if (valuesInstance is null && value is string stringValue)
-            {
-                if (valuesArgs.Any(t => t == typeof(string)))
-                {
-                    valuesInstance = TryConvertViaImplicit(innerType, stringValue);
-                }
-
-                if (valuesInstance is null && valuesArgs.Any(t => t == typeof(Uri))
-                    && Uri.TryCreate(stringValue, UriKind.RelativeOrAbsolute, out var uri))
-                {
-                    valuesInstance = TryConvertViaImplicit(innerType, uri);
-                }
-
-                // Date/number-typed Values inside OneOrMany (mirrors the bare-Values path)
-                if (valuesInstance is null
-                    && TryParseDateOrNumber(valuesArgs, stringValue, out var parsed)
-                    && parsed is not null)
-                {
-                    valuesInstance = TryConvertViaImplicit(innerType, parsed);
-                }
-            }
-
-            if (valuesInstance is not null)
-            {
-                // Build OneOrMany<> from Values<>
-                var oneOrMany = TryConvertViaImplicit(targetType, valuesInstance);
-                if (oneOrMany is not null)
-                {
-                    property.SetValue(instance, oneOrMany);
-                    return true;
-                }
-
-                // Try constructor
-                try
-                {
-                    var oneOrManyInstance = Activator.CreateInstance(targetType, valuesInstance);
-                    property.SetValue(instance, oneOrManyInstance);
-                    return true;
-                }
-                catch (MissingMethodException)
-                {
-                    // Fall through
-                }
-                catch (TargetInvocationException)
-                {
-                    // Fall through
-                }
-            }
+            var valuesInstance = TryBuildValues(innerType, valuesArgs, value);
+            if (valuesInstance is not null && TryWrapAndSet(property, instance, targetType, valuesInstance))
+                return true;
         }
 
         // Handle simple OneOrMany<T> where T is not Values<> (e.g., OneOrMany<Uri>)
         if (value is string strValue && innerType == typeof(Uri)
-            && Uri.TryCreate(strValue, UriKind.RelativeOrAbsolute, out var directUri))
-        {
-            var oneOrMany = TryConvertViaImplicit(targetType, directUri);
-            if (oneOrMany is not null)
-            {
-                property.SetValue(instance, oneOrMany);
-                return true;
-            }
-        }
+            && Uri.TryCreate(strValue, UriKind.RelativeOrAbsolute, out var directUri)
+            && TrySetViaImplicit(property, instance, targetType, directUri))
+            return true;
 
         // General fallback: try converting value directly to OneOrMany<T> via T
         var directConverted = TryConvertViaImplicit(innerType, value);
-        if (directConverted is not null)
+        return directConverted is not null
+               && TrySetViaImplicit(property, instance, targetType, directConverted);
+    }
+
+    /// <summary>
+    /// Builds a Schema.NET <c>Values&lt;…&gt;</c> instance (the inner type of a
+    /// <c>OneOrMany&lt;Values&lt;…&gt;&gt;</c>) from a resolved value. First tries a direct
+    /// implicit conversion; then, for a string value, the string-specific coercions IN ORDER:
+    /// string-typed arg → Uri (RelativeOrAbsolute) → date/number. Returns <c>null</c> when none apply.
+    /// </summary>
+    private static object? TryBuildValues(Type innerType, Type[] valuesArgs, object value)
+    {
+        // Build Values<> via implicit operator
+        var valuesInstance = TryConvertViaImplicit(innerType, value);
+
+        // If value is a string, try string-specific conversions
+        if (valuesInstance is null && value is string stringValue)
         {
-            var oneOrMany = TryConvertViaImplicit(targetType, directConverted);
-            if (oneOrMany is not null)
+            if (valuesArgs.Any(t => t == typeof(string)))
             {
-                property.SetValue(instance, oneOrMany);
-                return true;
+                valuesInstance = TryConvertViaImplicit(innerType, stringValue);
+            }
+
+            if (valuesInstance is null && valuesArgs.Any(t => t == typeof(Uri))
+                && Uri.TryCreate(stringValue, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                valuesInstance = TryConvertViaImplicit(innerType, uri);
+            }
+
+            // Date/number-typed Values inside OneOrMany (mirrors the bare-Values path)
+            if (valuesInstance is null
+                && TryParseDateOrNumber(valuesArgs, stringValue, out var parsed)
+                && parsed is not null)
+            {
+                valuesInstance = TryConvertViaImplicit(innerType, parsed);
             }
         }
 
-        return false;
+        return valuesInstance;
+    }
+
+    /// <summary>
+    /// Converts <paramref name="value"/> to <paramref name="targetType"/> via an implicit
+    /// operator and, on success, assigns it to <paramref name="property"/>. Returns <c>false</c>
+    /// (leaving the property untouched) when no implicit conversion applies.
+    /// </summary>
+    private static bool TrySetViaImplicit(PropertyInfo property, Thing instance, Type targetType, object value)
+    {
+        var converted = TryConvertViaImplicit(targetType, value);
+        if (converted is null)
+            return false;
+
+        property.SetValue(instance, converted);
+        return true;
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> into <paramref name="targetType"/> and assigns it, trying
+    /// the implicit operator first and then the Activator constructor (the
+    /// implicit-operator-then-Activator-constructor pattern). Returns <c>false</c> when both fail.
+    /// </summary>
+    private static bool TryWrapAndSet(PropertyInfo property, Thing instance, Type targetType, object value)
+        => TrySetViaImplicit(property, instance, targetType, value)
+           || TryConstructAndSet(property, instance, targetType, value);
+
+    /// <summary>
+    /// Constructs <paramref name="targetType"/> from a single argument via
+    /// <see cref="Activator.CreateInstance(Type, object[])"/> and assigns it. Returns <c>false</c>
+    /// on <see cref="MissingMethodException"/> / <see cref="TargetInvocationException"/> (no
+    /// matching constructor) so callers can fall through. Shared by the OneOrMany/collection builders.
+    /// </summary>
+    private static bool TryConstructAndSet(PropertyInfo property, Thing instance, Type targetType, object arg)
+    {
+        try
+        {
+            var created = Activator.CreateInstance(targetType, arg);
+            property.SetValue(instance, created);
+            return true;
+        }
+        catch (MissingMethodException)
+        {
+            return false;
+        }
+        catch (TargetInvocationException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Umbraco.Community.SchemeWeaver/Services/SchemeWeaverService.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/SchemeWeaverService.cs
@@ -376,9 +376,9 @@ public class SchemeWeaverService : ISchemeWeaverService
         {
             object? value = pm.SourceType switch
             {
-                "static" => pm.StaticValue,
-                "blockContent" => $"[BlockList: {pm.ContentTypePropertyAlias} → {pm.NestedSchemaTypeName}]",
-                "complexType" => $"[{pm.NestedSchemaTypeName}]",
+                SchemeWeaverConstants.SourceTypes.Static => pm.StaticValue,
+                SchemeWeaverConstants.SourceTypes.BlockContent => $"[BlockList: {pm.ContentTypePropertyAlias} → {pm.NestedSchemaTypeName}]",
+                SchemeWeaverConstants.SourceTypes.ComplexType => $"[{pm.NestedSchemaTypeName}]",
                 _ when SchemeWeaverConstants.BuiltInProperties.IsBuiltIn(pm.ContentTypePropertyAlias) =>
                     GetBuiltInMockValue(pm.ContentTypePropertyAlias),
                 _ when !string.IsNullOrEmpty(pm.ContentTypePropertyAlias) => $"[{pm.ContentTypePropertyAlias}]",

--- a/src/Umbraco.Community.SchemeWeaver/Services/Validation/Rules/RuleHelpers.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Validation/Rules/RuleHelpers.cs
@@ -145,4 +145,106 @@ internal static class RuleHelpers
                 break;
         }
     }
+
+    /// <summary>
+    /// Emit one <see cref="ValidationIssue"/> for each <see cref="FieldRule"/> whose
+    /// field is not present in the required form. This is the declarative counterpart
+    /// of the long if-chains that rules would otherwise inline: each rule names a field,
+    /// a severity, a <see cref="PresenceKind"/> (which presence helper decides "present")
+    /// and the message to raise when it is absent. Field lookup stays case-tolerant
+    /// (camelCase then PascalCase) via <see cref="TryGetField"/>.
+    /// </summary>
+    public static IEnumerable<ValidationIssue> CheckFields(
+        JsonElement node, string path, string schemaType, IEnumerable<FieldRule> rules)
+    {
+        foreach (var rule in rules)
+        {
+            if (!IsPresent(node, rule.Field, rule.Presence))
+                yield return new ValidationIssue(
+                    rule.Severity, schemaType, $"{path}.{ToCamelCase(rule.Field)}", rule.Message);
+        }
+    }
+
+    /// <summary>
+    /// Validate the <c>offers</c> sub-block for the Vehicle-listing rich result: each
+    /// Offer must carry a <c>price</c> (or a <c>priceSpecification</c> object/array) and a
+    /// <c>priceCurrency</c>. A single Offer object is pathed as <c>…offers</c>; an array of
+    /// Offers is pathed as <c>…offers[i]</c>. Nothing is emitted when <c>offers</c> is absent
+    /// or is not a non-empty array/object — its presence is asserted separately as a field.
+    /// </summary>
+    public static IEnumerable<ValidationIssue> CheckOffers(JsonElement node, string path, string schemaType)
+    {
+        if (!HasNonEmptyArrayOrObject(node, "Offers") || !TryGetField(node, "Offers", out var offers))
+            yield break;
+
+        var many = offers.ValueKind == JsonValueKind.Array;
+        var i = 0;
+        foreach (var offer in EnumerateOneOrMany(offers))
+        {
+            var offerPath = many ? $"{path}.offers[{i}]" : $"{path}.offers";
+            if (!HasNonEmptyString(offer, "Price")
+                && !HasNonEmptyArrayOrObject(offer, "PriceSpecification"))
+                yield return new ValidationIssue(ValidationSeverity.Critical, schemaType,
+                    $"{offerPath}.price",
+                    "Offer is missing `price` — required for vehicle-listing rich results.");
+            if (!HasNonEmptyString(offer, "PriceCurrency"))
+                yield return new ValidationIssue(ValidationSeverity.Critical, schemaType,
+                    $"{offerPath}.priceCurrency",
+                    "Offer is missing `priceCurrency` — required (3-letter ISO 4217 code).");
+            i++;
+        }
+    }
+
+    /// <summary>
+    /// Decide whether <paramref name="field"/> is present on <paramref name="node"/> in the
+    /// form demanded by <paramref name="kind"/>, delegating to the existing presence helpers.
+    /// </summary>
+    private static bool IsPresent(JsonElement node, string field, PresenceKind kind) => kind switch
+    {
+        PresenceKind.NonEmptyString => HasNonEmptyString(node, field),
+        PresenceKind.StringOrObject => HasNonEmptyString(node, field) || HasNonEmptyArrayOrObject(node, field),
+        PresenceKind.ArrayOrObject => HasNonEmptyArrayOrObject(node, field),
+        PresenceKind.Image => HasImage(node, ToCamelCase(field)),
+        PresenceKind.IsoDateOrString => HasIsoDate(node, field) || HasNonEmptyString(node, field),
+        PresenceKind.FieldPresent => TryGetField(node, field, out _),
+        _ => false,
+    };
+
+    private static IEnumerable<JsonElement> EnumerateOneOrMany(JsonElement value) =>
+        value.ValueKind == JsonValueKind.Array ? value.EnumerateArray() : new[] { value };
 }
+
+/// <summary>
+/// How <see cref="RuleHelpers.CheckFields"/> decides a field is "present". Each value maps
+/// onto one of the presence helpers <see cref="RuleHelpers"/> already exposes, keeping the
+/// polymorphic and case-tolerant lookup rules in one place.
+/// </summary>
+internal enum PresenceKind
+{
+    /// <summary>Satisfied by a non-empty string (or Schema.NET array-of-one string).</summary>
+    NonEmptyString,
+
+    /// <summary>Satisfied by EITHER a non-empty string OR a non-empty array/object.</summary>
+    StringOrObject,
+
+    /// <summary>Satisfied by a non-empty array or an object.</summary>
+    ArrayOrObject,
+
+    /// <summary>Satisfied by an image value (URL string, ImageObject, or array of either).</summary>
+    Image,
+
+    /// <summary>Satisfied by an ISO 8601 date OR any non-empty string.</summary>
+    IsoDateOrString,
+
+    /// <summary>Satisfied merely by the field being present (any value/shape).</summary>
+    FieldPresent,
+}
+
+/// <summary>
+/// A single declarative field-presence check for <see cref="RuleHelpers.CheckFields"/>:
+/// the schema field name (PascalCase, resolved case-tolerantly and lower-cased for the
+/// reported path), the <see cref="ValidationSeverity"/> to raise, the <see cref="PresenceKind"/>
+/// that decides "present", and the message emitted when the field is missing.
+/// </summary>
+internal readonly record struct FieldRule(
+    string Field, ValidationSeverity Severity, PresenceKind Presence, string Message);

--- a/src/Umbraco.Community.SchemeWeaver/Services/Validation/Rules/VehicleRule.cs
+++ b/src/Umbraco.Community.SchemeWeaver/Services/Validation/Rules/VehicleRule.cs
@@ -18,112 +18,53 @@ public sealed class VehicleRule : ITypeRule
         "Vehicle", "Car", "Motorcycle",
     };
 
+    /// <summary>
+    /// Declarative table of the flat field-presence checks. Order is presentational only —
+    /// each row yields at most one issue, keyed on its own path. The offers sub-block
+    /// (per-Offer price/priceCurrency) is validated separately by <see cref="RuleHelpers.CheckOffers"/>.
+    /// </summary>
+    private static readonly FieldRule[] Fields =
+    {
+        new("Name", ValidationSeverity.Critical, PresenceKind.NonEmptyString,
+            "Missing `name` — required to title the vehicle in listing rich results."),
+        new("Image", ValidationSeverity.Critical, PresenceKind.Image,
+            "Missing `image` — required for vehicle-listing rich results; Google uses it as the thumbnail."),
+        new("Offers", ValidationSeverity.Critical, PresenceKind.ArrayOrObject,
+            "Missing `offers` — required (Offer with `price` and `priceCurrency`) for vehicle-listing rich results."),
+        new("Description", ValidationSeverity.Warning, PresenceKind.NonEmptyString,
+            "Missing `description` — recommended for the vehicle snippet text."),
+        new("Brand", ValidationSeverity.Warning, PresenceKind.StringOrObject,
+            "Missing `brand` — recommended (string or Brand/Organization, e.g. the make of the vehicle)."),
+        new("Manufacturer", ValidationSeverity.Warning, PresenceKind.StringOrObject,
+            "Missing `manufacturer` — recommended (Organization) so Google can attribute the vehicle to its maker."),
+        new("ModelDate", ValidationSeverity.Warning, PresenceKind.IsoDateOrString,
+            "Missing `modelDate` — recommended; the release date of the model."),
+        new("VehicleModelDate", ValidationSeverity.Warning, PresenceKind.IsoDateOrString,
+            "Missing `vehicleModelDate` — recommended; the model year of the specific vehicle."),
+        new("VehicleIdentificationNumber", ValidationSeverity.Warning, PresenceKind.NonEmptyString,
+            "Missing `vehicleIdentificationNumber` — recommended (17-character VIN) for individual-vehicle listings."),
+        new("MileageFromOdometer", ValidationSeverity.Warning, PresenceKind.FieldPresent,
+            "Missing `mileageFromOdometer` — recommended (QuantitativeValue with unit) for used vehicles."),
+        new("ItemCondition", ValidationSeverity.Warning, PresenceKind.StringOrObject,
+            "Missing `itemCondition` — recommended (e.g. `https://schema.org/NewCondition`, `/UsedCondition`)."),
+        new("Color", ValidationSeverity.Warning, PresenceKind.NonEmptyString,
+            "Missing `color` — recommended; helps users filter by exterior colour."),
+        new("FuelType", ValidationSeverity.Warning, PresenceKind.StringOrObject,
+            "Missing `fuelType` — recommended (e.g. `Gasoline`, `Diesel`, `Electric`)."),
+        new("BodyType", ValidationSeverity.Warning, PresenceKind.StringOrObject,
+            "Missing `bodyType` — recommended (e.g. `SUV`, `Sedan`, `Hatchback`)."),
+    };
+
     public bool AppliesTo(string schemaType) => Matches.Contains(schemaType);
 
     public IEnumerable<ValidationIssue> Check(JsonElement node, string path)
     {
         var type = node.GetProperty("@type").GetString() ?? "Vehicle";
 
-        if (!RuleHelpers.HasNonEmptyString(node, "Name"))
-            yield return new ValidationIssue(ValidationSeverity.Critical, type,
-                $"{path}.name",
-                "Missing `name` — required to title the vehicle in listing rich results.");
+        foreach (var issue in RuleHelpers.CheckFields(node, path, type, Fields))
+            yield return issue;
 
-        if (!RuleHelpers.HasImage(node))
-            yield return new ValidationIssue(ValidationSeverity.Critical, type,
-                $"{path}.image",
-                "Missing `image` — required for vehicle-listing rich results; Google uses it as the thumbnail.");
-
-        var hasOffers = RuleHelpers.HasNonEmptyArrayOrObject(node, "Offers");
-        if (!hasOffers)
-        {
-            yield return new ValidationIssue(ValidationSeverity.Critical, type,
-                $"{path}.offers",
-                "Missing `offers` — required (Offer with `price` and `priceCurrency`) for vehicle-listing rich results.");
-        }
-        else if (RuleHelpers.TryGetField(node, "Offers", out var offers))
-        {
-            var many = offers.ValueKind == JsonValueKind.Array;
-            var i = 0;
-            foreach (var offer in EnumerateOneOrMany(offers))
-            {
-                var offerPath = many ? $"{path}.offers[{i}]" : $"{path}.offers";
-                if (!RuleHelpers.HasNonEmptyString(offer, "Price")
-                    && !RuleHelpers.HasNonEmptyArrayOrObject(offer, "PriceSpecification"))
-                    yield return new ValidationIssue(ValidationSeverity.Critical, type,
-                        $"{offerPath}.price",
-                        "Offer is missing `price` — required for vehicle-listing rich results.");
-                if (!RuleHelpers.HasNonEmptyString(offer, "PriceCurrency"))
-                    yield return new ValidationIssue(ValidationSeverity.Critical, type,
-                        $"{offerPath}.priceCurrency",
-                        "Offer is missing `priceCurrency` — required (3-letter ISO 4217 code).");
-                i++;
-            }
-        }
-
-        if (!RuleHelpers.HasNonEmptyString(node, "Description"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.description",
-                "Missing `description` — recommended for the vehicle snippet text.");
-
-        if (!RuleHelpers.HasNonEmptyArrayOrObject(node, "Brand")
-            && !RuleHelpers.HasNonEmptyString(node, "Brand"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.brand",
-                "Missing `brand` — recommended (string or Brand/Organization, e.g. the make of the vehicle).");
-
-        if (!RuleHelpers.HasNonEmptyArrayOrObject(node, "Manufacturer")
-            && !RuleHelpers.HasNonEmptyString(node, "Manufacturer"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.manufacturer",
-                "Missing `manufacturer` — recommended (Organization) so Google can attribute the vehicle to its maker.");
-
-        if (!RuleHelpers.HasIsoDate(node, "ModelDate")
-            && !RuleHelpers.HasNonEmptyString(node, "ModelDate"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.modelDate",
-                "Missing `modelDate` — recommended; the release date of the model.");
-
-        if (!RuleHelpers.HasIsoDate(node, "VehicleModelDate")
-            && !RuleHelpers.HasNonEmptyString(node, "VehicleModelDate"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.vehicleModelDate",
-                "Missing `vehicleModelDate` — recommended; the model year of the specific vehicle.");
-
-        if (!RuleHelpers.HasNonEmptyString(node, "VehicleIdentificationNumber"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.vehicleIdentificationNumber",
-                "Missing `vehicleIdentificationNumber` — recommended (17-character VIN) for individual-vehicle listings.");
-
-        if (!RuleHelpers.TryGetField(node, "MileageFromOdometer", out _))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.mileageFromOdometer",
-                "Missing `mileageFromOdometer` — recommended (QuantitativeValue with unit) for used vehicles.");
-
-        if (!RuleHelpers.HasNonEmptyString(node, "ItemCondition")
-            && !RuleHelpers.HasNonEmptyArrayOrObject(node, "ItemCondition"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.itemCondition",
-                "Missing `itemCondition` — recommended (e.g. `https://schema.org/NewCondition`, `/UsedCondition`).");
-
-        if (!RuleHelpers.HasNonEmptyString(node, "Color"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.color",
-                "Missing `color` — recommended; helps users filter by exterior colour.");
-
-        if (!RuleHelpers.HasNonEmptyString(node, "FuelType")
-            && !RuleHelpers.HasNonEmptyArrayOrObject(node, "FuelType"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.fuelType",
-                "Missing `fuelType` — recommended (e.g. `Gasoline`, `Diesel`, `Electric`).");
-
-        if (!RuleHelpers.HasNonEmptyString(node, "BodyType")
-            && !RuleHelpers.HasNonEmptyArrayOrObject(node, "BodyType"))
-            yield return new ValidationIssue(ValidationSeverity.Warning, type,
-                $"{path}.bodyType",
-                "Missing `bodyType` — recommended (e.g. `SUV`, `Sedan`, `Hatchback`).");
+        foreach (var issue in RuleHelpers.CheckOffers(node, path, type))
+            yield return issue;
     }
-
-    private static IEnumerable<JsonElement> EnumerateOneOrMany(JsonElement value) =>
-        value.ValueKind == JsonValueKind.Array ? value.EnumerateArray() : new[] { value };
 }

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/MappingAdvisorTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/MappingAdvisorTests.cs
@@ -174,6 +174,22 @@ public class MappingAdvisorTests
         advice.Should().NotContain(a => a.Kind == MappingAdviceKind.MissingRequiredNestedProperty);
     }
 
+    // --- Multiple checks fire on one entry: all checks run (no short-circuit) and the
+    // emission order is fixed (WrapInListItem before MissingRequired). ---
+
+    [Fact]
+    public void AdviseEntry_UnwrappedQuestionListMissingAnswer_EmitsWrapThenMissingInOrder()
+    {
+        // itemListElement is an ordered list (Check 2 fires: not wrapped) AND the Question route
+        // omits acceptedAnswer (Check 3 fires) — a single entry yields both, in check order.
+        var advice = _sut.AdviseEntry(new MappingEntryInput(
+            "ItemList", "itemListElement", "blockContent", ResolverConfig: Routes("Question", "name")));
+
+        advice.Select(a => a.Kind).Should().Equal(
+            MappingAdviceKind.WrapInListItem,
+            MappingAdviceKind.MissingRequiredNestedProperty);
+    }
+
     // --- Check 4: persistence ---
 
     [Fact]

--- a/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Validation/Rules/VehicleRulePriceSpecificationTests.cs
+++ b/tests/Umbraco.Community.SchemeWeaver.Tests/Unit/Validation/Rules/VehicleRulePriceSpecificationTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using FluentAssertions;
+using Umbraco.Community.SchemeWeaver.Services.Validation;
+using Umbraco.Community.SchemeWeaver.Services.Validation.Rules;
+using Xunit;
+
+namespace Umbraco.Community.SchemeWeaver.Tests.Unit.Validation.Rules;
+
+/// <summary>
+/// Locks the Vehicle-specific offer contract that the flat-if refactor must preserve:
+/// unlike <see cref="ProductRule"/> (which accepts <c>priceSpecification</c> only as a
+/// string), <see cref="VehicleRule"/> treats a <c>priceSpecification</c> object OR array
+/// as satisfying the per-Offer `price` requirement. Not covered by the existing suite.
+/// </summary>
+public class VehicleRulePriceSpecificationTests
+{
+    private readonly VehicleRule _sut = new();
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void Check_OfferWithPriceSpecificationObject_NoPriceIssue()
+    {
+        const string json = """
+            {
+              "@type": "Car",
+              "name": "2024 Example Saloon",
+              "image": "https://example.com/images/car.jpg",
+              "offers": {
+                "@type": "Offer",
+                "priceSpecification": { "@type": "PriceSpecification", "price": "9.99", "priceCurrency": "GBP" },
+                "priceCurrency": "GBP"
+              }
+            }
+            """;
+        var issues = _sut.Check(Parse(json), "$").ToList();
+
+        issues.Should().NotContain(i => i.Path == "$.offers.price");
+    }
+
+    [Fact]
+    public void Check_OfferWithPriceSpecificationArray_NoPriceIssue()
+    {
+        const string json = """
+            {
+              "@type": "Car",
+              "name": "2024 Example Saloon",
+              "image": "https://example.com/images/car.jpg",
+              "offers": {
+                "@type": "Offer",
+                "priceSpecification": [ { "@type": "UnitPriceSpecification", "price": "9.99", "priceCurrency": "GBP" } ],
+                "priceCurrency": "GBP"
+              }
+            }
+            """;
+        var issues = _sut.Check(Parse(json), "$").ToList();
+
+        issues.Should().NotContain(i => i.Path == "$.offers.price");
+    }
+
+    [Fact]
+    public void Check_OfferWithNeitherPriceNorPriceSpecification_YieldsCriticalPrice()
+    {
+        const string json = """
+            {
+              "@type": "Car",
+              "name": "2024 Example Saloon",
+              "image": "https://example.com/images/car.jpg",
+              "offers": { "@type": "Offer", "priceCurrency": "GBP" }
+            }
+            """;
+        var issues = _sut.Check(Parse(json), "$").ToList();
+
+        issues.Should().ContainSingle(i =>
+            i.Severity == ValidationSeverity.Critical
+            && i.Path == "$.offers.price");
+    }
+}


### PR DESCRIPTION
## What & why

The prior code-quality review closed all 35 original findings but left a **"Remaining hotspots"** list — 10 methods still above cyclomatic complexity (CC) 20, in dispatch-heavy resolvers, mappers, serializers and validation rules. This PR is that next sweep: it reduces the complexity of **all 10** with **behaviour-preserving** refactors, plus a cross-cutting `SourceTypes` constants hygiene pass.

**Pure refactor — no behaviour change, no new features.** Every change is pinned by the existing test suite (no assertion was weakened; new tests are additive only).

## Result

| Metric (whole repo) | Before (`f899a77`) | After |
|---|---|---|
| Methods with **CC > 20** | 10 | **0** |
| **Max CC** | 30 | **20** |
| Core project **avg CC** | 4.89 | 4.53 |
| Core project **CC > 10** | 48 | 41 |

Average complexity fell despite ~48 new small helper methods — genuine reduction, not just redistribution. The single highest method is now `StructuralEnricher.EnrichOne` at CC 20 (not in the hotspot-10; natural next candidate).

### Per-method CC before → after

| Cluster | Method | File | CC |
|---|---|---|---|
| A | `VehicleRule.Check` | Validation/Rules/VehicleRule.cs | 29 → 4 |
| B | `BlockContentResolver.Resolve` | Resolvers/BlockContentResolver.cs | 30 → ~9 |
| C | `JsonLdGenerator.GenerateJsonLdCore` | JsonLdGenerator.cs | 23 → ~12 |
| C | `JsonLdGenerator.ResolveComplexTypeFromConfig` | JsonLdGenerator.cs | 21 → ~10 |
| D | `SchemaAutoMapper.SuggestMappings` | SchemaAutoMapper.cs | 24 → ~11 |
| D | `SchemaAutoMapper.BoostForEditorMatch` | SchemaAutoMapper.cs | 21 → ~5 |
| E | `MappingAdvisor.AdviseEntry` | Advisory/MappingAdvisor.cs | 25 → ~5 |
| F | `SchemaMappingSerializer.DeserializeCoreAsync` | uSync/SchemaMappingSerializer.cs | 29 → 5 |
| G | `SchemaPropertySetter.SetPropertyValue` | SchemaPropertySetter.cs | 26 → ~5 |
| G | `SchemaPropertySetter.TrySetOneOrManyValue` | SchemaPropertySetter.cs | 22 → ~10 |

## How

Each hotspot was refactored in an isolated worktree by a specialist, then adversarially reviewed by a devil's-advocate reviewer, then merged and re-verified in the main tree.

- **Foundation** — new `SchemeWeaverConstants.SourceTypes` (const strings + `IsCrossNode` / `ResolvesToNestedThing` helpers); retired the duplicated source-type magic-strings, preserving every call site's comparison policy (ordinal on the render path, `OrdinalIgnoreCase` on advisory/validation/enrichment).
- **A** — `VehicleRule.Check` → declarative `FieldRule[]` table driven by new reusable `RuleHelpers.CheckFields`/`CheckOffers`.
- **B** — `Resolve` split into `ResolveStringList`/`ResolveRouted`/`ResolveLegacy` + verbatim `ExtractStrings` switch + unified `MapBlocks`.
- **C** — extract `ApplyPropertyMapping`/`TryApplyReference`/`TryApplyExplicitId` + `ResolveSubValue`/`TryAdoptImageObject`; per-property try/catch degrade boundary kept inside the loop; two-phase resolve→adopt→apply and the 3-clause ImageObject-adoption guard preserved.
- **D** — extract `TryMatchTier`/`TryBuiltIn`/`ResolveUnmatched`; `BoostForEditorMatch` → rule table (flat +15 makes `Any` equivalent).
- **E** — three independent advisory checks extracted; all still always run, in order.
- **F** — extract `ReadMapping`/`ReadPropertyMapping` + `XElement` helpers; CDATA reads, defaults, save-before-children ordering and unconditional full-replace preserved.
- **G** — `SetPropertyValue` → ordered strategy table; **the REV-1 ImageObject→Uri downgrade block was moved verbatim** (predicate/order/position unchanged); stays in lock-step with `SchemaRangeValidator`.

## Verification

- **Both Umbraco legs green** (mirrors CI):
  - Umbraco 18: `Failed: 0, Passed: 980`
  - Umbraco 17: `Failed: 0, Passed: 995`
  - Includes the WebApplicationFactory integration tests (`SchemeWeaverApiControllerTests` preview/render, `HeuristicRichCoverageTests` gold-coverage gate) and `JsonLdGeneratorTests.MediaLogoAdoption_ValidatorAndRenderAgree`.
- **Adversarial review** — a devil's-advocate reviewer per wave tried to construct a diverging input for every refactor. Verdicts: **CONFIRMED-SAFE** across all clusters. The only divergence anyone could construct is a cosmetic reordering of Vehicle *offer* sub-issues within `ValidationResult.Issues` (Cluster A) — identical set/severities/messages/paths, no test or consumer depends on issue order, and `ValidationResult`'s semantics (`CriticalCount`/`HasCritical`/`IsValid`) are order-independent.
- CC measured build-free with a Roslyn syntactic pass (same McCabe rule as the original review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
