### PR TITLE
fix(test): repair 5 red PropertyMappingTableElement MSW tests (uui-button click)

### DIFF
--- a/src/Umbraco.Community.SchemeWeaver/App_Plugins/SchemeWeaver/src/components/property-mapping-table.element.test.ts
+++ b/src/Umbraco.Community.SchemeWeaver/App_Plugins/SchemeWeaver/src/components/property-mapping-table.element.test.ts
@@ -56,7 +56,7 @@ describe('PropertyMappingTableElement', () => {
     const rows = el.shadowRoot!.querySelectorAll('uui-table-row');
     const removeBtn = (rows[1] as HTMLElement).querySelector('.actions-cell .remove-row-btn') as HTMLElement;
     expect(removeBtn).to.exist;
-    removeBtn.click();
+    removeBtn.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
 
     expect(eventDetail).to.exist;
     expect(eventDetail.mappings).to.have.lengthOf(3);
@@ -160,7 +160,7 @@ describe('PropertyMappingTableElement', () => {
     });
 
     const sourceChip = el.shadowRoot!.querySelector('.source-chip') as HTMLElement;
-    sourceChip?.click();
+    sourceChip?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     expect(eventFired).to.be.true;
     expect(eventDetail.index).to.equal(0);
     expect(eventDetail.currentSourceType).to.equal(SourceType.Property);
@@ -217,7 +217,7 @@ describe('PropertyMappingTableElement', () => {
     });
 
     const configButton = el.shadowRoot!.querySelector('.block-actions uui-button') as HTMLElement;
-    configButton?.click();
+    configButton?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
 
     expect(eventFired).to.be.true;
     expect(eventDetail.nestedSchemaTypeName).to.equal('Question');
@@ -269,7 +269,7 @@ describe('PropertyMappingTableElement', () => {
     });
 
     const chip = el.shadowRoot!.querySelector('.source-chip') as HTMLElement;
-    chip?.click();
+    chip?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     expect(eventDetail).to.exist;
     expect(eventDetail.isComplexType).to.be.true;
     expect(eventDetail.editorAlias).to.equal('Umbraco.BlockList');
@@ -298,7 +298,7 @@ describe('PropertyMappingTableElement', () => {
     });
 
     const configButton = el.shadowRoot!.querySelector('.block-actions uui-button') as HTMLElement;
-    configButton?.click();
+    configButton?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     expect(eventFired).to.be.true;
     expect(eventDetail.schemaPropertyName).to.equal('author');
     expect(eventDetail.acceptedTypes).to.deep.equal(['Organization', 'Person']);


### PR DESCRIPTION
## What & why

CI's **Frontend → "Unit & component tests (MSW)"** job has been red on `main` since `c1d26e6` — 5 `PropertyMappingTableElement` tests fail (e.g. `run 28703932465` on `f899a77` shows both C# legs green and this MSW step failing with the identical 5 assertions).

`c1d26e6` reworked the table's source/actions cells to use `<uui-button>` for the source chip, the row-remove button, and the configure buttons. The tests still drive them with `element.click()`. Calling `.click()` on a `<uui-button>` **host** does not produce a bubbling click that reaches the parent component's host-level `@click` handler under the MSW harness, so the handlers never ran (`eventFired` stayed false; the remove test saw a null `mappings-changed` detail). The **plain** web-test-runner config happened to keep passing, which is how the regression slipped through.

The component is correct — it works in the real backoffice (production `uui-button`) and under the plain config. This is a **test-only** fix.

## The fix

Replace `element.click()` with `element.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }))` in the 5 interaction tests — a more faithful simulation of a real user click that works under **both** the plain and MSW configs. No component change, no assertion change.

## Verification

Full frontend suites now green (both mirror CI):
- `npm test` (plain): **213 passed, 0 failed**
- `npm run test:msw` (MSW): **288 passed, 0 failed** (was 283 passed / 5 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)